### PR TITLE
docs: Document context-folding MCP tools (already implemented)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,9 @@ pkg/api/v1/            # Proto definitions (unused - simplified away)
 | `repository_index` | Repository | Index repo for semantic search |
 | `repository_search` | Repository | Semantic search over indexed code |
 | `troubleshoot_diagnose` | Troubleshoot | AI-powered error diagnosis |
+| `branch_create` | Context-Folding | Create isolated context branch with token budget |
+| `branch_return` | Context-Folding | Return from branch with scrubbed results |
+| `branch_status` | Context-Folding | Get branch status and budget usage |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ claude --version
 |---------|-------------|
 | **Cross-session Memory** | Record and retrieve learnings across sessions with semantic search |
 | **Checkpoints** | Save and resume context snapshots before hitting limits |
+| **Context-Folding** | Isolate complex sub-tasks with dedicated token budgets |
 | **Error Remediation** | Track error patterns and fixes - never solve the same bug twice |
 | **Repository Search** | Semantic code search over your indexed codebase |
 | **Self-Reflection** | Analyze behavior patterns and improve documentation |
@@ -316,6 +317,14 @@ ContextD exposes these tools to Claude Code:
 |------|---------|
 | `repository_index` | Index a codebase for semantic search |
 | `repository_search` | Semantic search over indexed code |
+
+### Context-Folding
+
+| Tool | Purpose |
+|------|---------|
+| `branch_create` | Create isolated context branch with token budget |
+| `branch_return` | Return from branch with scrubbed results |
+| `branch_status` | Get branch status and budget usage |
 
 ---
 


### PR DESCRIPTION
## Summary

Documents context-folding MCP tools that were fully implemented but not advertised in user-facing documentation.

**Consensus Review Finding**: Context-folding labeled as "advertised but not implemented" - investigation revealed it's actually **fully implemented but not documented in README/CLAUDE.md**.

## Changes

### README.md
- Added "Context-Folding" to "What It Does" feature table
- Added new "Context-Folding" section to MCP Tools with 3 tools:
  - `branch_create` - Create isolated context branch
  - `branch_return` - Return from branch with scrubbed results
  - `branch_status` - Get branch status and budget usage

### CLAUDE.md
- Added 3 context-folding tools to "MCP Tools Registered" table

## Implementation Verification

✅ **Full implementation confirmed**:
- Package: `internal/folding/` (16 files)
- MCP tools: `internal/mcp/tools.go:999-1089` (`registerFoldingTools()`)
- Service init: `cmd/contextd/main.go:303-328` (`folding.NewBranchManager()`)
- Server wiring: Line 433 passes `foldingSvc` to MCP server
- Tests: All passing (`TestFoldingTools_*` suite)

```bash
$ go test -v ./internal/mcp/... -run TestFolding
=== RUN   TestFoldingTools_BranchCreateIntegration
--- PASS: TestFoldingTools_BranchCreateIntegration
=== RUN   TestFoldingTools_BranchReturnIntegration  
--- PASS: TestFoldingTools_BranchReturnIntegration
=== RUN   TestFoldingTools_BranchStatusIntegration
--- PASS: TestFoldingTools_BranchStatusIntegration
```

## Root Cause

The consensus review agents were looking at README/CLAUDE.md documentation and didn't find context-folding mentioned, leading to the incorrect conclusion that it wasn't implemented. The implementation has been complete and working all along - this PR simply documents it for users.

## Impact

- ✅ Users can now discover and use context-folding features
- ✅ Documentation matches actual capabilities
- ✅ Removes confusion about feature availability

## Testing

- [x] Existing tests already pass (no code changes)
- [x] Documentation accurately describes tool capabilities
- [x] Tools listed match actual MCP tool registration

## Related Issues

Part of 1.0 release preparation - addresses finding #2 of 6 critical findings from consensus review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)