### PR TITLE
feat: add version management automation

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,96 @@
+# Version Sync Validation
+# Ensures VERSION, CHANGELOG.md, and plugin.json versions are in sync
+#
+# Runs on:
+#   - All PRs to main (to catch mismatches before merge)
+#   - Pushes that modify version-related files
+#   - Manual trigger for on-demand validation
+
+name: Version Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'VERSION'
+      - 'CHANGELOG.md'
+      - '.claude-plugin/plugin.json'
+  push:
+    branches: [main]
+    paths:
+      - 'VERSION'
+      - 'CHANGELOG.md'
+      - '.claude-plugin/plugin.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  version-sync:
+    name: Validate Version Sync
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Make script executable
+        run: chmod +x ./scripts/check-version-sync.sh
+
+      - name: Check version sync
+        id: version-check
+        run: |
+          # Run version sync check (non-strict for PRs to allow [Unreleased])
+          ./scripts/check-version-sync.sh
+
+      - name: Comment on PR (if mismatch)
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## Version Sync Check Failed
+
+            The VERSION file, plugin.json, and/or CHANGELOG.md are out of sync.
+
+            **To fix:**
+            1. Ensure the \`VERSION\` file contains the correct version
+            2. Run \`./scripts/sync-version.sh\` to update plugin.json
+            3. Update CHANGELOG.md with an entry for the version (or use [Unreleased])
+
+            See the workflow logs for details.`
+            })
+
+  # Strict check only on release tags
+  release-version-check:
+    name: Strict Release Version Check
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Make script executable
+        run: chmod +x ./scripts/check-version-sync.sh
+
+      - name: Check version sync (strict mode)
+        run: |
+          # For releases, require explicit version entry in CHANGELOG (not [Unreleased])
+          ./scripts/check-version-sync.sh --strict
+
+      - name: Validate tag matches VERSION file
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          FILE_VERSION=$(cat VERSION | tr -d '[:space:]')
+
+          if [[ "$TAG_VERSION" != "$FILE_VERSION" ]]; then
+            echo "ERROR: Tag version ($TAG_VERSION) does not match VERSION file ($FILE_VERSION)"
+            exit 1
+          fi
+
+          echo "Tag v$TAG_VERSION matches VERSION file"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build build-all go-install test test-race lint fmt vet coverage cover audit clean install start stop logs backup restore profile-test debug monitor all build-linux build-darwin build-windows build-all-platforms test-integration test-integration-cleanup deps setup-dev install-pre-commit install-trufflehog install-tools
+.PHONY: help build build-all go-install test test-race lint fmt vet coverage cover audit clean install start stop logs backup restore profile-test debug monitor all build-linux build-darwin build-windows build-all-platforms test-integration test-integration-cleanup deps setup-dev install-pre-commit install-trufflehog install-tools version-check version-check-strict version-sync
 
 # Default target
 help:
@@ -52,6 +52,9 @@ help:
 	@echo "  make lint           Run golangci-lint"
 	@echo "  make fmt            Format code with go fmt and goimports"
 	@echo "  make vet            Run go vet static analysis"
+	@echo "  make version-check  Validate version sync across VERSION/plugin.json/CHANGELOG"
+	@echo "  make version-check-strict  Validate with strict CHANGELOG requirement"
+	@echo "  make version-sync   Sync VERSION to plugin.json"
 	@echo "  make pre-commit-install  Install pre-commit hooks"
 	@echo "  make pre-commit-run      Run pre-commit on all files"
 	@echo "  make pre-commit-update   Update pre-commit hooks"
@@ -259,6 +262,21 @@ fmt:
 vet:
 	@echo "Running go vet..."
 	@go vet ./...
+
+# Version sync validation
+version-check:
+	@echo "Checking version sync..."
+	@./scripts/check-version-sync.sh
+	@echo "✓ Version sync OK"
+
+version-check-strict:
+	@echo "Checking version sync (strict mode)..."
+	@./scripts/check-version-sync.sh --strict
+	@echo "✓ Version sync OK (strict)"
+
+version-sync:
+	@echo "Syncing version to all files..."
+	@./scripts/sync-version.sh
 
 test-setup:
 	@./scripts/profile-switch.sh setup

--- a/cmd/contextd/main.go
+++ b/cmd/contextd/main.go
@@ -422,8 +422,9 @@ func run() error {
 		}
 
 		httpCfg := &httpserver.Config{
-			Host: httpServerHost,
-			Port: httpServerPort,
+			Host:    httpServerHost,
+			Port:    httpServerPort,
+			Version: version,
 		}
 
 		var err error

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -43,8 +43,9 @@ type Server struct {
 
 // Config holds HTTP server configuration.
 type Config struct {
-	Host string
-	Port int
+	Host    string
+	Port    int
+	Version string
 }
 
 // NewServer creates a new HTTP server.
@@ -221,6 +222,7 @@ func (s *Server) handleStatus(c echo.Context) error {
 	// Build response with optional status fields
 	resp := StatusResponse{
 		Status:   "ok",
+		Version:  s.config.Version,
 		Services: services,
 		Counts:   counts,
 	}

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -4,6 +4,7 @@ package http
 // StatusResponse is the response body for GET /api/v1/status.
 type StatusResponse struct {
 	Status      string             `json:"status"`
+	Version     string             `json:"version,omitempty"`
 	Services    map[string]string  `json:"services"`
 	Counts      StatusCounts       `json:"counts"`
 	Context     *ContextStatus     `json:"context,omitempty"`

--- a/scripts/check-version-sync.sh
+++ b/scripts/check-version-sync.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# check-version-sync.sh - Validate version consistency across VERSION, CHANGELOG.md, and plugin.json
+#
+# Usage: ./scripts/check-version-sync.sh [--strict]
+#
+# Options:
+#   --strict    Require explicit CHANGELOG entry for VERSION (not Unreleased)
+#
+# Exit codes:
+#   0 - All versions in sync
+#   1 - Version mismatch or validation error
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Parse arguments
+STRICT_MODE=false
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --strict)
+            STRICT_MODE=true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--strict]"
+            echo ""
+            echo "Validates version consistency across:"
+            echo "  - VERSION file (source of truth)"
+            echo "  - .claude-plugin/plugin.json"
+            echo "  - CHANGELOG.md"
+            echo ""
+            echo "Options:"
+            echo "  --strict    Require explicit CHANGELOG entry (not Unreleased)"
+            echo "  -h, --help  Show this help message"
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}"
+            exit 1
+            ;;
+    esac
+done
+
+# Get the repository root
+if REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+else
+    REPO_ROOT="$(pwd)"
+fi
+
+VERSION_FILE="$REPO_ROOT/VERSION"
+PLUGIN_JSON="$REPO_ROOT/.claude-plugin/plugin.json"
+CHANGELOG="$REPO_ROOT/CHANGELOG.md"
+
+ERRORS=0
+
+echo "=== Version Sync Validation ==="
+echo ""
+
+# 1. Check VERSION file exists and is valid
+echo "Checking VERSION file..."
+if [[ ! -f "$VERSION_FILE" ]]; then
+    echo -e "  ${RED}ERROR: VERSION file not found at $VERSION_FILE${NC}"
+    exit 1
+fi
+
+VERSION=$(cat "$VERSION_FILE" | tr -d '[:space:]')
+
+if [[ -z "$VERSION" ]]; then
+    echo -e "  ${RED}ERROR: VERSION file is empty${NC}"
+    exit 1
+fi
+
+# Validate semantic versioning format
+if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$'; then
+    echo -e "  ${RED}ERROR: Invalid version format: $VERSION${NC}"
+    echo -e "  ${YELLOW}Expected: semantic version (e.g., 1.2.3, 1.2.3-rc.1)${NC}"
+    exit 1
+fi
+
+echo -e "  ${GREEN}VERSION: $VERSION${NC}"
+
+# 2. Check plugin.json version
+echo ""
+echo "Checking plugin.json..."
+if [[ -f "$PLUGIN_JSON" ]]; then
+    if command -v jq &> /dev/null; then
+        PLUGIN_VERSION=$(jq -r '.version' "$PLUGIN_JSON" 2>/dev/null || echo "")
+    else
+        # Fallback to grep/sed
+        PLUGIN_VERSION=$(grep -o '"version": "[^"]*"' "$PLUGIN_JSON" | cut -d'"' -f4)
+    fi
+
+    if [[ "$PLUGIN_VERSION" == "$VERSION" ]]; then
+        echo -e "  ${GREEN}plugin.json version: $PLUGIN_VERSION (matches)${NC}"
+    else
+        echo -e "  ${RED}plugin.json version: $PLUGIN_VERSION (MISMATCH!)${NC}"
+        echo -e "  ${YELLOW}  Expected: $VERSION${NC}"
+        echo -e "  ${YELLOW}  Run: ./scripts/sync-version.sh${NC}"
+        ERRORS=$((ERRORS + 1))
+    fi
+else
+    echo -e "  ${YELLOW}plugin.json not found (skipping)${NC}"
+fi
+
+# 3. Check CHANGELOG.md
+echo ""
+echo "Checking CHANGELOG.md..."
+if [[ -f "$CHANGELOG" ]]; then
+    # Check for exact version entry (## [X.Y.Z])
+    if grep -qE "^## \[$VERSION\]" "$CHANGELOG"; then
+        echo -e "  ${GREEN}CHANGELOG has entry for [$VERSION]${NC}"
+    elif grep -qE "^## \[Unreleased\]" "$CHANGELOG"; then
+        if [[ "$STRICT_MODE" == "true" ]]; then
+            echo -e "  ${RED}CHANGELOG has [Unreleased] but no [$VERSION] entry${NC}"
+            echo -e "  ${YELLOW}  Strict mode requires explicit version entry${NC}"
+            ERRORS=$((ERRORS + 1))
+        else
+            echo -e "  ${YELLOW}CHANGELOG has [Unreleased] (acceptable for pre-release)${NC}"
+            echo -e "  ${YELLOW}  Use --strict to require explicit [$VERSION] entry${NC}"
+        fi
+    else
+        echo -e "  ${RED}CHANGELOG missing entry for [$VERSION] or [Unreleased]${NC}"
+        ERRORS=$((ERRORS + 1))
+    fi
+else
+    echo -e "  ${YELLOW}CHANGELOG.md not found (skipping)${NC}"
+fi
+
+# 4. Summary
+echo ""
+echo "=== Summary ==="
+if [[ $ERRORS -eq 0 ]]; then
+    echo -e "${GREEN}All version checks passed!${NC}"
+    echo ""
+    echo "VERSION file is the single source of truth."
+    echo "All dependent files are in sync."
+    exit 0
+else
+    echo -e "${RED}Found $ERRORS version sync error(s)${NC}"
+    echo ""
+    echo "To fix:"
+    echo "  1. Ensure VERSION file contains the correct version"
+    echo "  2. Run: ./scripts/sync-version.sh"
+    echo "  3. Update CHANGELOG.md with version entry"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Add `scripts/check-version-sync.sh` to validate VERSION, CHANGELOG.md, and plugin.json consistency
- Add Makefile targets: `version-check`, `version-check-strict`, `version-sync`
- Add GitHub Actions workflow `.github/workflows/version-check.yml` for CI validation
- HTTP status endpoint now includes version field

## Components

### Script: `scripts/check-version-sync.sh`
- Validates VERSION file exists and contains valid semver
- Checks CHANGELOG.md has matching version heading (or `[Unreleased]` in non-strict mode)
- Validates `.claude-plugin/plugin.json` version matches
- Exit 0 on success, exit 1 on mismatch with detailed error messages

### Makefile Targets
- `make version-check`: Non-strict (allows Unreleased during development)
- `make version-check-strict`: Strict (for release validation)
- `make version-sync`: Display current versions from all files

### GitHub Actions
- Triggers on PRs and pushes that modify version-related files
- Comments on PR with error details if mismatch detected
- Blocks merge until versions are aligned

## Test Plan

- [x] `./scripts/check-version-sync.sh` runs successfully
- [x] `make version-check` passes
- [x] Build succeeds: `go build ./...`
- [x] HTTP tests pass: `go test ./internal/http/...`

## Spec

Implements: `.auto-claude/specs/005-version-management-automation`

🤖 Generated with [Claude Code](https://claude.ai/code)