### PR TITLE
feat(reasoningbank): session-level memory granularity (#137)

### DIFF
--- a/internal/reasoningbank/session_buffer.go
+++ b/internal/reasoningbank/session_buffer.go
@@ -1,0 +1,143 @@
+package reasoningbank
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// TurnEntry represents a single turn buffered for session summarization.
+type TurnEntry struct {
+	Title     string
+	Content   string
+	Outcome   Outcome
+	Tags      []string
+	Timestamp time.Time
+}
+
+// SessionBuffer holds buffered turns for a single session.
+type SessionBuffer struct {
+	SessionID   string
+	ProjectID   string
+	SessionDate time.Time
+	Turns       []TurnEntry
+}
+
+// SessionBufferManager manages in-memory buffers for session-level memory accumulation.
+// Thread-safe for concurrent access from multiple MCP tool calls.
+type SessionBufferManager struct {
+	mu       sync.RWMutex
+	buffers  map[string]*SessionBuffer // keyed by "projectID:sessionID"
+	maxTurns int
+}
+
+// NewSessionBufferManager creates a new buffer manager.
+// maxTurns limits the number of turns per session buffer (0 = unlimited).
+func NewSessionBufferManager(maxTurns int) *SessionBufferManager {
+	return &SessionBufferManager{
+		buffers:  make(map[string]*SessionBuffer),
+		maxTurns: maxTurns,
+	}
+}
+
+// bufferKey returns the map key for a project+session pair.
+func bufferKey(projectID, sessionID string) string {
+	return projectID + ":" + sessionID
+}
+
+// BufferTurn adds a turn entry to the session buffer.
+// Creates the buffer if it doesn't exist yet.
+// If maxTurns is exceeded, the oldest turn is dropped.
+func (m *SessionBufferManager) BufferTurn(projectID, sessionID string, entry TurnEntry) error {
+	if projectID == "" {
+		return ErrEmptyProjectID
+	}
+	if sessionID == "" {
+		return fmt.Errorf("session ID cannot be empty")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := bufferKey(projectID, sessionID)
+	buf, ok := m.buffers[key]
+	if !ok {
+		buf = &SessionBuffer{
+			SessionID:   sessionID,
+			ProjectID:   projectID,
+			SessionDate: time.Now(),
+			Turns:       make([]TurnEntry, 0, 64),
+		}
+		m.buffers[key] = buf
+	}
+
+	// Set timestamp if not provided
+	if entry.Timestamp.IsZero() {
+		entry.Timestamp = time.Now()
+	}
+
+	buf.Turns = append(buf.Turns, entry)
+
+	// Enforce max turns limit by dropping oldest
+	if m.maxTurns > 0 && len(buf.Turns) > m.maxTurns {
+		excess := len(buf.Turns) - m.maxTurns
+		buf.Turns = buf.Turns[excess:]
+	}
+
+	return nil
+}
+
+// GetBuffer returns the current buffer for a session. Returns nil if no buffer exists.
+func (m *SessionBufferManager) GetBuffer(projectID, sessionID string) *SessionBuffer {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	key := bufferKey(projectID, sessionID)
+	buf, ok := m.buffers[key]
+	if !ok {
+		return nil
+	}
+
+	// Return a copy to avoid external mutation
+	cp := *buf
+	cp.Turns = make([]TurnEntry, len(buf.Turns))
+	copy(cp.Turns, buf.Turns)
+	return &cp
+}
+
+// FlushBuffer removes and returns the buffer for a session.
+// Returns nil if no buffer exists.
+func (m *SessionBufferManager) FlushBuffer(projectID, sessionID string) *SessionBuffer {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := bufferKey(projectID, sessionID)
+	buf, ok := m.buffers[key]
+	if !ok {
+		return nil
+	}
+
+	delete(m.buffers, key)
+	return buf
+}
+
+// Count returns the number of buffered turns for a session.
+// Returns 0 if no buffer exists.
+func (m *SessionBufferManager) Count(projectID, sessionID string) int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	key := bufferKey(projectID, sessionID)
+	buf, ok := m.buffers[key]
+	if !ok {
+		return 0
+	}
+	return len(buf.Turns)
+}
+
+// ActiveSessions returns the number of sessions with active buffers.
+func (m *SessionBufferManager) ActiveSessions() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.buffers)
+}

--- a/internal/reasoningbank/session_buffer_test.go
+++ b/internal/reasoningbank/session_buffer_test.go
@@ -1,0 +1,339 @@
+package reasoningbank
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBufferTurn_Basic(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewSessionBufferManager(0)
+
+	entry := TurnEntry{
+		Title:   "Fix auth bug",
+		Content: "Resolved nil pointer in token validation",
+		Outcome: OutcomeSuccess,
+		Tags:    []string{"auth", "bugfix"},
+	}
+
+	err := mgr.BufferTurn("proj-1", "sess-1", entry)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, mgr.Count("proj-1", "sess-1"))
+
+	buf := mgr.GetBuffer("proj-1", "sess-1")
+	require.NotNil(t, buf)
+	assert.Equal(t, "proj-1", buf.ProjectID)
+	assert.Equal(t, "sess-1", buf.SessionID)
+	require.Len(t, buf.Turns, 1)
+	assert.Equal(t, "Fix auth bug", buf.Turns[0].Title)
+	assert.Equal(t, "Resolved nil pointer in token validation", buf.Turns[0].Content)
+	assert.Equal(t, OutcomeSuccess, buf.Turns[0].Outcome)
+	assert.Equal(t, []string{"auth", "bugfix"}, buf.Turns[0].Tags)
+	assert.False(t, buf.Turns[0].Timestamp.IsZero(), "timestamp should be auto-set")
+}
+
+func TestBufferTurn_MultipleTurns(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewSessionBufferManager(0)
+
+	entries := []TurnEntry{
+		{Title: "Turn 1", Content: "First turn content", Outcome: OutcomeSuccess},
+		{Title: "Turn 2", Content: "Second turn content", Outcome: OutcomeFailure},
+		{Title: "Turn 3", Content: "Third turn content", Outcome: OutcomeSuccess},
+	}
+
+	for _, e := range entries {
+		err := mgr.BufferTurn("proj-1", "sess-1", e)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, 3, mgr.Count("proj-1", "sess-1"))
+
+	buf := mgr.GetBuffer("proj-1", "sess-1")
+	require.NotNil(t, buf)
+	require.Len(t, buf.Turns, 3)
+
+	// Verify order is preserved
+	for i, e := range entries {
+		assert.Equal(t, e.Title, buf.Turns[i].Title, "turn %d title mismatch", i)
+		assert.Equal(t, e.Content, buf.Turns[i].Content, "turn %d content mismatch", i)
+		assert.Equal(t, e.Outcome, buf.Turns[i].Outcome, "turn %d outcome mismatch", i)
+	}
+
+	// Verify timestamps are monotonically non-decreasing
+	for i := 1; i < len(buf.Turns); i++ {
+		assert.False(t, buf.Turns[i].Timestamp.Before(buf.Turns[i-1].Timestamp),
+			"turn %d timestamp should not be before turn %d", i, i-1)
+	}
+}
+
+func TestBufferTurn_MaxTurnsEnforced(t *testing.T) {
+	t.Parallel()
+
+	maxTurns := 3
+	mgr := NewSessionBufferManager(maxTurns)
+
+	// Buffer 5 turns, only last 3 should remain
+	for i := 0; i < 5; i++ {
+		entry := TurnEntry{
+			Title:   fmt.Sprintf("Turn %d", i),
+			Content: fmt.Sprintf("Content %d", i),
+			Outcome: OutcomeSuccess,
+		}
+		err := mgr.BufferTurn("proj-1", "sess-1", entry)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, maxTurns, mgr.Count("proj-1", "sess-1"))
+
+	buf := mgr.GetBuffer("proj-1", "sess-1")
+	require.NotNil(t, buf)
+	require.Len(t, buf.Turns, maxTurns)
+
+	// Oldest turns (0, 1) should have been dropped; turns 2, 3, 4 remain
+	assert.Equal(t, "Turn 2", buf.Turns[0].Title)
+	assert.Equal(t, "Turn 3", buf.Turns[1].Title)
+	assert.Equal(t, "Turn 4", buf.Turns[2].Title)
+}
+
+func TestBufferTurn_ValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewSessionBufferManager(0)
+	entry := TurnEntry{Title: "Test", Content: "Content"}
+
+	t.Run("empty_project_id", func(t *testing.T) {
+		t.Parallel()
+		err := mgr.BufferTurn("", "sess-1", entry)
+		assert.ErrorIs(t, err, ErrEmptyProjectID)
+	})
+
+	t.Run("empty_session_id", func(t *testing.T) {
+		t.Parallel()
+		err := mgr.BufferTurn("proj-1", "", entry)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "session ID cannot be empty")
+	})
+}
+
+func TestGetBuffer_ReturnsNilForMissing(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewSessionBufferManager(0)
+
+	buf := mgr.GetBuffer("nonexistent-proj", "nonexistent-sess")
+	assert.Nil(t, buf)
+}
+
+func TestGetBuffer_ReturnsCopy(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewSessionBufferManager(0)
+
+	err := mgr.BufferTurn("proj-1", "sess-1", TurnEntry{
+		Title:   "Original",
+		Content: "Original content",
+		Outcome: OutcomeSuccess,
+	})
+	require.NoError(t, err)
+
+	// Get a copy
+	buf1 := mgr.GetBuffer("proj-1", "sess-1")
+	require.NotNil(t, buf1)
+	require.Len(t, buf1.Turns, 1)
+
+	// Mutate the returned copy
+	buf1.Turns[0].Title = "Mutated"
+	buf1.Turns = append(buf1.Turns, TurnEntry{Title: "Extra"})
+
+	// Get another copy -- should still show original data
+	buf2 := mgr.GetBuffer("proj-1", "sess-1")
+	require.NotNil(t, buf2)
+	require.Len(t, buf2.Turns, 1, "internal buffer should not be affected by external mutation")
+	assert.Equal(t, "Original", buf2.Turns[0].Title, "internal turn title should not be mutated")
+}
+
+func TestFlushBuffer_RemovesBuffer(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewSessionBufferManager(0)
+
+	err := mgr.BufferTurn("proj-1", "sess-1", TurnEntry{
+		Title:   "Turn to flush",
+		Content: "Will be flushed",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, mgr.ActiveSessions())
+
+	// Flush
+	flushed := mgr.FlushBuffer("proj-1", "sess-1")
+	require.NotNil(t, flushed)
+	assert.Equal(t, "sess-1", flushed.SessionID)
+	assert.Equal(t, "proj-1", flushed.ProjectID)
+	require.Len(t, flushed.Turns, 1)
+	assert.Equal(t, "Turn to flush", flushed.Turns[0].Title)
+
+	// Subsequent get returns nil
+	assert.Nil(t, mgr.GetBuffer("proj-1", "sess-1"))
+	assert.Equal(t, 0, mgr.Count("proj-1", "sess-1"))
+	assert.Equal(t, 0, mgr.ActiveSessions())
+}
+
+func TestFlushBuffer_ReturnsNilForMissing(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewSessionBufferManager(0)
+
+	flushed := mgr.FlushBuffer("nonexistent-proj", "nonexistent-sess")
+	assert.Nil(t, flushed)
+}
+
+func TestCount_EmptySession(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewSessionBufferManager(0)
+
+	assert.Equal(t, 0, mgr.Count("proj-1", "sess-nonexistent"))
+}
+
+func TestSessionIsolation(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewSessionBufferManager(0)
+
+	// Buffer turns in different sessions and projects
+	err := mgr.BufferTurn("proj-1", "sess-1", TurnEntry{Title: "P1S1", Content: "Project 1 Session 1"})
+	require.NoError(t, err)
+	err = mgr.BufferTurn("proj-1", "sess-2", TurnEntry{Title: "P1S2", Content: "Project 1 Session 2"})
+	require.NoError(t, err)
+	err = mgr.BufferTurn("proj-2", "sess-1", TurnEntry{Title: "P2S1", Content: "Project 2 Session 1"})
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, mgr.ActiveSessions())
+
+	// Verify each session has exactly 1 turn with correct content
+	buf11 := mgr.GetBuffer("proj-1", "sess-1")
+	require.NotNil(t, buf11)
+	require.Len(t, buf11.Turns, 1)
+	assert.Equal(t, "P1S1", buf11.Turns[0].Title)
+
+	buf12 := mgr.GetBuffer("proj-1", "sess-2")
+	require.NotNil(t, buf12)
+	require.Len(t, buf12.Turns, 1)
+	assert.Equal(t, "P1S2", buf12.Turns[0].Title)
+
+	buf21 := mgr.GetBuffer("proj-2", "sess-1")
+	require.NotNil(t, buf21)
+	require.Len(t, buf21.Turns, 1)
+	assert.Equal(t, "P2S1", buf21.Turns[0].Title)
+
+	// Flush one session, verify others are unaffected
+	flushed := mgr.FlushBuffer("proj-1", "sess-1")
+	require.NotNil(t, flushed)
+	assert.Equal(t, 2, mgr.ActiveSessions())
+
+	assert.Nil(t, mgr.GetBuffer("proj-1", "sess-1"))
+	assert.NotNil(t, mgr.GetBuffer("proj-1", "sess-2"))
+	assert.NotNil(t, mgr.GetBuffer("proj-2", "sess-1"))
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewSessionBufferManager(100)
+
+	const (
+		numGoroutines = 20
+		turnsPerGo    = 50
+	)
+
+	var wg sync.WaitGroup
+
+	// Concurrent writers to the same session
+	for g := 0; g < numGoroutines; g++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < turnsPerGo; i++ {
+				entry := TurnEntry{
+					Title:   fmt.Sprintf("goroutine-%d-turn-%d", id, i),
+					Content: fmt.Sprintf("content from goroutine %d turn %d", id, i),
+					Outcome: OutcomeSuccess,
+				}
+				_ = mgr.BufferTurn("proj-concurrent", "sess-concurrent", entry)
+			}
+		}(g)
+	}
+
+	// Concurrent readers
+	for g := 0; g < numGoroutines/2; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < turnsPerGo; i++ {
+				_ = mgr.GetBuffer("proj-concurrent", "sess-concurrent")
+				_ = mgr.Count("proj-concurrent", "sess-concurrent")
+				_ = mgr.ActiveSessions()
+			}
+		}()
+	}
+
+	// Concurrent flushers on different sessions to avoid interfering with writers
+	for g := 0; g < numGoroutines/4; g++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			sessID := fmt.Sprintf("flush-sess-%d", id)
+			for i := 0; i < turnsPerGo; i++ {
+				entry := TurnEntry{
+					Title:   fmt.Sprintf("flush-turn-%d", i),
+					Content: "flush content",
+				}
+				_ = mgr.BufferTurn("proj-flush", sessID, entry)
+			}
+			_ = mgr.FlushBuffer("proj-flush", sessID)
+		}(g)
+	}
+
+	wg.Wait()
+
+	// After all writers finish, the shared session should have exactly maxTurns entries
+	// because 20 goroutines * 50 turns = 1000, capped at 100
+	count := mgr.Count("proj-concurrent", "sess-concurrent")
+	assert.Equal(t, 100, count, "buffer should be capped at maxTurns")
+
+	// Flushed sessions should be gone
+	for g := 0; g < numGoroutines/4; g++ {
+		sessID := fmt.Sprintf("flush-sess-%d", g)
+		assert.Nil(t, mgr.GetBuffer("proj-flush", sessID), "flushed session %s should be nil", sessID)
+	}
+}
+
+func TestBufferTurn_PreservesExplicitTimestamp(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewSessionBufferManager(0)
+
+	explicit := time.Date(2025, 6, 15, 10, 30, 0, 0, time.UTC)
+	entry := TurnEntry{
+		Title:     "With timestamp",
+		Content:   "Has explicit timestamp",
+		Timestamp: explicit,
+	}
+
+	err := mgr.BufferTurn("proj-1", "sess-1", entry)
+	require.NoError(t, err)
+
+	buf := mgr.GetBuffer("proj-1", "sess-1")
+	require.NotNil(t, buf)
+	require.Len(t, buf.Turns, 1)
+	assert.Equal(t, explicit, buf.Turns[0].Timestamp, "explicit timestamp should be preserved")
+}

--- a/internal/reasoningbank/session_summarizer.go
+++ b/internal/reasoningbank/session_summarizer.go
@@ -1,0 +1,271 @@
+package reasoningbank
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// SessionSummarizer aggregates flushed session buffers into session-level memories.
+//
+// The summarization pipeline:
+//  1. Aggregate turns by outcome (success vs failure)
+//  2. Run fact extraction on aggregated content
+//  3. Build template-based summary incorporating extracted facts
+//  4. Create Memory with session metadata (SessionID, SessionDate, Granularity)
+//  5. Return memories for storage via service.Record()
+type SessionSummarizer struct {
+	extractor FactExtractor
+	logger    *zap.Logger
+}
+
+// NewSessionSummarizer creates a new session summarizer.
+func NewSessionSummarizer(extractor FactExtractor, logger *zap.Logger) (*SessionSummarizer, error) {
+	if extractor == nil {
+		return nil, fmt.Errorf("fact extractor cannot be nil")
+	}
+	if logger == nil {
+		return nil, fmt.Errorf("logger cannot be nil")
+	}
+
+	return &SessionSummarizer{
+		extractor: extractor,
+		logger:    logger,
+	}, nil
+}
+
+// outcomeGroup holds turns aggregated by outcome.
+type outcomeGroup struct {
+	outcome Outcome
+	turns   []TurnEntry
+	tags    map[string]struct{}
+}
+
+// Summarize processes a flushed session buffer and produces session-level memories.
+//
+// The returned memories have SessionID, SessionDate, and Granularity fields set.
+// The caller is responsible for storing them via service.Record().
+//
+// Returns one memory per outcome group (success and/or failure) found in the buffer.
+// Returns nil with no error if the buffer is empty.
+func (s *SessionSummarizer) Summarize(ctx context.Context, buf *SessionBuffer) ([]*Memory, error) {
+	if buf == nil {
+		return nil, fmt.Errorf("session buffer cannot be nil")
+	}
+	if len(buf.Turns) == 0 {
+		s.logger.Debug("empty session buffer, skipping summarization",
+			zap.String("session_id", buf.SessionID),
+			zap.String("project_id", buf.ProjectID))
+		return nil, nil
+	}
+
+	s.logger.Info("summarizing session buffer",
+		zap.String("session_id", buf.SessionID),
+		zap.String("project_id", buf.ProjectID),
+		zap.Int("turns", len(buf.Turns)))
+
+	// Step 1: Aggregate turns by outcome
+	groups := s.aggregateByOutcome(buf.Turns)
+
+	var memories []*Memory
+
+	for _, group := range groups {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		// Step 2: Build combined content from turns
+		combinedContent := s.buildCombinedContent(group.turns)
+
+		// Step 3: Extract facts from combined content
+		referenceDate := buf.SessionDate
+		if referenceDate.IsZero() {
+			referenceDate = time.Now()
+		}
+
+		facts, err := s.extractor.Extract(ctx, combinedContent, referenceDate)
+		if err != nil {
+			s.logger.Warn("fact extraction failed for outcome group, continuing without facts",
+				zap.String("session_id", buf.SessionID),
+				zap.String("outcome", string(group.outcome)),
+				zap.Error(err))
+			// Continue without facts - they're supplementary
+		}
+
+		// Step 4: Build template-based summary
+		title := s.buildTitle(buf.SessionID, group.outcome, len(group.turns))
+		content := s.buildContent(group, facts)
+
+		// Collect unique tags
+		tags := make([]string, 0, len(group.tags))
+		for tag := range group.tags {
+			tags = append(tags, tag)
+		}
+
+		// Step 5: Create Memory with session metadata
+		memory, err := NewMemory(buf.ProjectID, title, content, group.outcome, tags)
+		if err != nil {
+			s.logger.Error("failed to create session memory",
+				zap.String("session_id", buf.SessionID),
+				zap.String("outcome", string(group.outcome)),
+				zap.Error(err))
+			continue
+		}
+
+		// Set session-level metadata
+		memory.SessionID = buf.SessionID
+		sessionDate := buf.SessionDate
+		memory.SessionDate = &sessionDate
+		memory.Granularity = GranularitySession
+		memory.Confidence = DistilledConfidence
+		memory.Description = fmt.Sprintf("Session summary (%d turns, %s)",
+			len(group.turns), group.outcome)
+
+		memories = append(memories, memory)
+
+		s.logger.Debug("created session memory",
+			zap.String("session_id", buf.SessionID),
+			zap.String("memory_id", memory.ID),
+			zap.String("outcome", string(group.outcome)),
+			zap.Int("turns", len(group.turns)),
+			zap.Int("facts", len(facts)))
+	}
+
+	s.logger.Info("session summarization completed",
+		zap.String("session_id", buf.SessionID),
+		zap.String("project_id", buf.ProjectID),
+		zap.Int("memories_created", len(memories)))
+
+	return memories, nil
+}
+
+// aggregateByOutcome groups turns by their outcome.
+func (s *SessionSummarizer) aggregateByOutcome(turns []TurnEntry) []outcomeGroup {
+	groupMap := make(map[Outcome]*outcomeGroup)
+
+	for _, turn := range turns {
+		outcome := turn.Outcome
+		// Default to success if outcome is empty
+		if outcome == "" {
+			outcome = OutcomeSuccess
+		}
+
+		g, ok := groupMap[outcome]
+		if !ok {
+			g = &outcomeGroup{
+				outcome: outcome,
+				turns:   make([]TurnEntry, 0),
+				tags:    make(map[string]struct{}),
+			}
+			groupMap[outcome] = g
+		}
+
+		g.turns = append(g.turns, turn)
+		for _, tag := range turn.Tags {
+			g.tags[tag] = struct{}{}
+		}
+	}
+
+	// Convert map to slice with deterministic ordering (success before failure)
+	groups := make([]outcomeGroup, 0, len(groupMap))
+	if g, ok := groupMap[OutcomeSuccess]; ok {
+		groups = append(groups, *g)
+	}
+	if g, ok := groupMap[OutcomeFailure]; ok {
+		groups = append(groups, *g)
+	}
+
+	return groups
+}
+
+// buildCombinedContent concatenates turn contents for fact extraction.
+func (s *SessionSummarizer) buildCombinedContent(turns []TurnEntry) string {
+	var b strings.Builder
+	for i, turn := range turns {
+		if i > 0 {
+			b.WriteString(". ")
+		}
+		if turn.Title != "" {
+			b.WriteString(turn.Title)
+			b.WriteString(": ")
+		}
+		b.WriteString(turn.Content)
+	}
+	return b.String()
+}
+
+// buildTitle generates a title for the session memory.
+func (s *SessionSummarizer) buildTitle(sessionID string, outcome Outcome, turnCount int) string {
+	prefix := "Session"
+	switch outcome {
+	case OutcomeSuccess:
+		prefix = "Success"
+	case OutcomeFailure:
+		prefix = "Anti-pattern"
+	}
+
+	// Truncate session ID for readability
+	shortID := sessionID
+	if len(shortID) > 8 {
+		shortID = shortID[:8]
+	}
+
+	return fmt.Sprintf("%s: Session %s (%d turns)", prefix, shortID, turnCount)
+}
+
+// buildContent generates the memory content from turns and extracted facts.
+func (s *SessionSummarizer) buildContent(group outcomeGroup, facts []Fact) string {
+	var b strings.Builder
+
+	// Section: Overview
+	b.WriteString("## Overview\n")
+	b.WriteString(fmt.Sprintf("Session with %d turns (outcome: %s).\n\n", len(group.turns), group.outcome))
+
+	// Section: Key Activities
+	b.WriteString("## Key Activities\n")
+	for _, turn := range group.turns {
+		if turn.Title != "" {
+			b.WriteString(fmt.Sprintf("- %s\n", turn.Title))
+		}
+	}
+	if b.Len() > 0 {
+		b.WriteString("\n")
+	}
+
+	// Section: Details
+	b.WriteString("## Details\n")
+	for _, turn := range group.turns {
+		b.WriteString(turn.Content)
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+
+	// Section: Extracted Facts (if any)
+	if len(facts) > 0 {
+		b.WriteString("## Extracted Facts\n")
+		for _, fact := range facts {
+			b.WriteString(fmt.Sprintf("- %s %s %s", fact.Subject, fact.Predicate, fact.Object))
+			if !fact.Timestamp.IsZero() {
+				b.WriteString(fmt.Sprintf(" (%s)", fact.Timestamp.Format("2006-01-02")))
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+
+	// Section: Tags
+	if len(group.tags) > 0 {
+		b.WriteString("## Tags\n")
+		tags := make([]string, 0, len(group.tags))
+		for tag := range group.tags {
+			tags = append(tags, tag)
+		}
+		b.WriteString(strings.Join(tags, ", "))
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}

--- a/internal/reasoningbank/session_summarizer_test.go
+++ b/internal/reasoningbank/session_summarizer_test.go
@@ -1,0 +1,336 @@
+package reasoningbank
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestNewSessionSummarizer(t *testing.T) {
+	t.Parallel()
+
+	logger := zaptest.NewLogger(t)
+	extractor := NewSimpleExtractor()
+
+	t.Run("valid inputs", func(t *testing.T) {
+		t.Parallel()
+		s, err := NewSessionSummarizer(extractor, logger)
+		require.NoError(t, err)
+		require.NotNil(t, s)
+	})
+
+	t.Run("nil extractor", func(t *testing.T) {
+		t.Parallel()
+		s, err := NewSessionSummarizer(nil, logger)
+		assert.Error(t, err)
+		assert.Nil(t, s)
+		assert.Contains(t, err.Error(), "fact extractor cannot be nil")
+	})
+
+	t.Run("nil logger", func(t *testing.T) {
+		t.Parallel()
+		s, err := NewSessionSummarizer(extractor, nil)
+		assert.Error(t, err)
+		assert.Nil(t, s)
+		assert.Contains(t, err.Error(), "logger cannot be nil")
+	})
+}
+
+func TestSummarize_NilBuffer(t *testing.T) {
+	t.Parallel()
+
+	s := newTestSummarizer(t)
+	memories, err := s.Summarize(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, memories)
+	assert.Contains(t, err.Error(), "session buffer cannot be nil")
+}
+
+func TestSummarize_EmptyBuffer(t *testing.T) {
+	t.Parallel()
+
+	s := newTestSummarizer(t)
+	buf := &SessionBuffer{
+		SessionID:   "sess-1",
+		ProjectID:   "proj-1",
+		SessionDate: time.Now(),
+		Turns:       []TurnEntry{},
+	}
+
+	memories, err := s.Summarize(context.Background(), buf)
+	assert.NoError(t, err)
+	assert.Nil(t, memories)
+}
+
+func TestSummarize_SingleSuccessTurn(t *testing.T) {
+	t.Parallel()
+
+	s := newTestSummarizer(t)
+	sessionDate := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+
+	buf := &SessionBuffer{
+		SessionID:   "sess-abc",
+		ProjectID:   "proj-1",
+		SessionDate: sessionDate,
+		Turns: []TurnEntry{
+			{
+				Title:   "Fix auth bug",
+				Content: "I implemented a retry mechanism for token refresh",
+				Outcome: OutcomeSuccess,
+				Tags:    []string{"go", "auth"},
+			},
+		},
+	}
+
+	memories, err := s.Summarize(context.Background(), buf)
+	require.NoError(t, err)
+	require.Len(t, memories, 1)
+
+	mem := memories[0]
+	assert.Equal(t, "proj-1", mem.ProjectID)
+	assert.Equal(t, "sess-abc", mem.SessionID)
+	assert.Equal(t, &sessionDate, mem.SessionDate)
+	assert.Equal(t, GranularitySession, mem.Granularity)
+	assert.Equal(t, OutcomeSuccess, mem.Outcome)
+	assert.Equal(t, DistilledConfidence, mem.Confidence)
+	assert.Contains(t, mem.Title, "Success")
+	assert.Contains(t, mem.Title, "sess-abc")
+	assert.Contains(t, mem.Content, "Fix auth bug")
+	assert.Contains(t, mem.Content, "retry mechanism")
+	assert.Contains(t, mem.Description, "1 turns")
+}
+
+func TestSummarize_MixedOutcomes(t *testing.T) {
+	t.Parallel()
+
+	s := newTestSummarizer(t)
+	sessionDate := time.Date(2025, 7, 1, 14, 0, 0, 0, time.UTC)
+
+	buf := &SessionBuffer{
+		SessionID:   "sess-mixed",
+		ProjectID:   "proj-2",
+		SessionDate: sessionDate,
+		Turns: []TurnEntry{
+			{
+				Title:   "Add caching",
+				Content: "I implemented Redis caching for API responses",
+				Outcome: OutcomeSuccess,
+				Tags:    []string{"redis", "caching"},
+			},
+			{
+				Title:   "Query optimization",
+				Content: "I learned about index optimization for PostgreSQL",
+				Outcome: OutcomeSuccess,
+				Tags:    []string{"postgres", "performance"},
+			},
+			{
+				Title:   "Deploy failure",
+				Content: "Deployment failed due to missing env var",
+				Outcome: OutcomeFailure,
+				Tags:    []string{"deploy"},
+			},
+		},
+	}
+
+	memories, err := s.Summarize(context.Background(), buf)
+	require.NoError(t, err)
+	require.Len(t, memories, 2, "should produce one memory per outcome")
+
+	// First should be success (deterministic ordering)
+	successMem := memories[0]
+	assert.Equal(t, OutcomeSuccess, successMem.Outcome)
+	assert.Equal(t, GranularitySession, successMem.Granularity)
+	assert.Contains(t, successMem.Title, "Success")
+	assert.Contains(t, successMem.Content, "Redis caching")
+	assert.Contains(t, successMem.Content, "index optimization")
+	assert.Contains(t, successMem.Description, "2 turns")
+
+	// Second should be failure
+	failureMem := memories[1]
+	assert.Equal(t, OutcomeFailure, failureMem.Outcome)
+	assert.Equal(t, GranularitySession, failureMem.Granularity)
+	assert.Contains(t, failureMem.Title, "Anti-pattern")
+	assert.Contains(t, failureMem.Content, "missing env var")
+	assert.Contains(t, failureMem.Description, "1 turns")
+}
+
+func TestSummarize_DefaultOutcome(t *testing.T) {
+	t.Parallel()
+
+	s := newTestSummarizer(t)
+
+	buf := &SessionBuffer{
+		SessionID:   "sess-default",
+		ProjectID:   "proj-1",
+		SessionDate: time.Now(),
+		Turns: []TurnEntry{
+			{
+				Title:   "Task",
+				Content: "Some content without explicit outcome",
+				Outcome: "", // Empty outcome should default to success
+				Tags:    []string{"general"},
+			},
+		},
+	}
+
+	memories, err := s.Summarize(context.Background(), buf)
+	require.NoError(t, err)
+	require.Len(t, memories, 1)
+	assert.Equal(t, OutcomeSuccess, memories[0].Outcome)
+}
+
+func TestSummarize_WithFactExtraction(t *testing.T) {
+	t.Parallel()
+
+	s := newTestSummarizer(t)
+	sessionDate := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+
+	buf := &SessionBuffer{
+		SessionID:   "sess-facts",
+		ProjectID:   "proj-1",
+		SessionDate: sessionDate,
+		Turns: []TurnEntry{
+			{
+				Title:   "Learning",
+				Content: "I learned about Go error handling patterns",
+				Outcome: OutcomeSuccess,
+				Tags:    []string{"go"},
+			},
+			{
+				Title:   "Implementation",
+				Content: "I implemented a circuit breaker for the API client",
+				Outcome: OutcomeSuccess,
+				Tags:    []string{"go", "resilience"},
+			},
+		},
+	}
+
+	memories, err := s.Summarize(context.Background(), buf)
+	require.NoError(t, err)
+	require.Len(t, memories, 1)
+
+	// The SimpleExtractor should find facts from "I learned..." and "I implemented..."
+	assert.Contains(t, memories[0].Content, "Extracted Facts")
+}
+
+func TestSummarize_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	s := newTestSummarizer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	buf := &SessionBuffer{
+		SessionID:   "sess-cancel",
+		ProjectID:   "proj-1",
+		SessionDate: time.Now(),
+		Turns: []TurnEntry{
+			{Title: "t1", Content: "c1", Outcome: OutcomeSuccess},
+			{Title: "t2", Content: "c2", Outcome: OutcomeFailure},
+		},
+	}
+
+	memories, err := s.Summarize(ctx, buf)
+	assert.Error(t, err)
+	assert.Nil(t, memories)
+}
+
+func TestSummarize_SessionMetadata(t *testing.T) {
+	t.Parallel()
+
+	s := newTestSummarizer(t)
+	sessionDate := time.Date(2025, 8, 20, 16, 30, 0, 0, time.UTC)
+
+	buf := &SessionBuffer{
+		SessionID:   "sess-metadata-test",
+		ProjectID:   "proj-meta",
+		SessionDate: sessionDate,
+		Turns: []TurnEntry{
+			{
+				Title:   "Work item",
+				Content: "Completed a task",
+				Outcome: OutcomeSuccess,
+			},
+		},
+	}
+
+	memories, err := s.Summarize(context.Background(), buf)
+	require.NoError(t, err)
+	require.Len(t, memories, 1)
+
+	mem := memories[0]
+	assert.Equal(t, "sess-metadata-test", mem.SessionID)
+	assert.Equal(t, &sessionDate, mem.SessionDate)
+	assert.Equal(t, GranularitySession, mem.Granularity)
+	assert.Equal(t, "proj-meta", mem.ProjectID)
+	assert.NotEmpty(t, mem.ID)
+	assert.NotZero(t, mem.CreatedAt)
+	assert.NotZero(t, mem.UpdatedAt)
+}
+
+func TestSummarize_TagDeduplication(t *testing.T) {
+	t.Parallel()
+
+	s := newTestSummarizer(t)
+
+	buf := &SessionBuffer{
+		SessionID:   "sess-tags",
+		ProjectID:   "proj-1",
+		SessionDate: time.Now(),
+		Turns: []TurnEntry{
+			{Title: "t1", Content: "c1", Outcome: OutcomeSuccess, Tags: []string{"go", "auth"}},
+			{Title: "t2", Content: "c2", Outcome: OutcomeSuccess, Tags: []string{"go", "testing"}},
+			{Title: "t3", Content: "c3", Outcome: OutcomeSuccess, Tags: []string{"auth", "testing"}},
+		},
+	}
+
+	memories, err := s.Summarize(context.Background(), buf)
+	require.NoError(t, err)
+	require.Len(t, memories, 1)
+
+	// Tags should be deduplicated: go, auth, testing = 3 unique tags
+	assert.Len(t, memories[0].Tags, 3)
+
+	tagSet := make(map[string]bool)
+	for _, tag := range memories[0].Tags {
+		tagSet[tag] = true
+	}
+	assert.True(t, tagSet["go"])
+	assert.True(t, tagSet["auth"])
+	assert.True(t, tagSet["testing"])
+}
+
+func TestSummarize_ZeroSessionDate(t *testing.T) {
+	t.Parallel()
+
+	s := newTestSummarizer(t)
+
+	buf := &SessionBuffer{
+		SessionID:   "sess-nodate",
+		ProjectID:   "proj-1",
+		SessionDate: time.Time{}, // Zero value
+		Turns: []TurnEntry{
+			{Title: "t1", Content: "I learned something today", Outcome: OutcomeSuccess},
+		},
+	}
+
+	// Should not panic - zero date means "use time.Now()" for fact extraction reference
+	memories, err := s.Summarize(context.Background(), buf)
+	require.NoError(t, err)
+	require.Len(t, memories, 1)
+}
+
+// newTestSummarizer creates a SessionSummarizer for testing.
+func newTestSummarizer(t *testing.T) *SessionSummarizer {
+	t.Helper()
+	logger := zaptest.NewLogger(t)
+	extractor := NewSimpleExtractor()
+	s, err := NewSessionSummarizer(extractor, logger)
+	require.NoError(t, err)
+	return s
+}


### PR DESCRIPTION
## Summary

- Add session-level memory granularity to buffer per-turn content and summarize on session end, storing one consolidated memory per session instead of hundreds of fragments
- Introduces `SessionBufferManager`, `SessionSummarizer`, `MemoryGranularity` type, `ReasoningBankConfig`, and `memory_consolidate_session` MCP tool
- Default granularity is "turn" (fully backward-compatible); session buffering only activates when `granularity=session` AND `SessionID` is set

## Test plan

- [x] `go test ./internal/reasoningbank/... -count=1` — all pass (buffer, summarizer, service integration)
- [x] `go test ./internal/mcp/... -count=1` — all pass (tool registration, handler updates)
- [x] `go test ./internal/config/... -count=1` — all pass (new config fields)
- [x] `go test ./internal/reasoningbank/... -race -count=1` — race-free (pre-existing vectorstore race excluded)
- [x] Consensus review: 5 agents (security, Go idioms, code quality, vulnerability, UX) — **APPROVE, 0 vetoes**

🤖 Generated with [Claude Code](https://claude.com/claude-code)