### PR TITLE
ci: add automated test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,56 @@
+# CI Test Suite
+# Runs unit tests with race detection, go vet, and generates coverage reports.
+# CGO_ENABLED=1 is required for FastEmbed (ONNX runtime).
+
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.7"
+          cache: true
+
+      - name: Install C dependencies
+        run: sudo apt-get update && sudo apt-get install -y gcc
+
+      - name: Verify dependencies
+        run: go mod verify
+
+      - name: Run go vet
+        env:
+          CGO_ENABLED: "1"
+        run: go vet ./...
+
+      - name: Run tests with race detection and coverage
+        env:
+          CGO_ENABLED: "1"
+        run: go test -race -coverprofile=coverage.out -covermode=atomic -v ./...
+
+      - name: Display coverage summary
+        run: go tool cover -func=coverage.out | tail -1
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: coverage.out
+          retention-days: 14


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test.yml` — the project's first CI test workflow
- Runs `go test -race` with coverage on push to main and PRs
- Includes `go vet`, module verification, and coverage artifact upload
- Uses CGO_ENABLED=1 (required for ONNX/chromem)

## Context
Identified as P0 in the new user experience review. The project previously had zero automated testing in CI — only a version-check workflow existed.

## Test plan
- [ ] Verify workflow triggers on PR creation
- [ ] Verify Go tests run with race detection
- [ ] Verify coverage artifact is uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)