### PR TITLE
chore(homebrew): bump formula to v0.5.0

### DIFF
--- a/Formula/contextd.rb
+++ b/Formula/contextd.rb
@@ -4,11 +4,11 @@
 class Contextd < Formula
   desc "AI context and reasoning engine for Claude Code"
   homepage "https://github.com/fyrsmithlabs/contextd"
-  version "0.4.0"
+  version "0.5.0"
   license "AGPL-3.0"
 
-  url "https://github.com/fyrsmithlabs/contextd/archive/refs/tags/v0.4.0.tar.gz"
-  sha256 "a847a754152225439fbeea8da11578b0ea740400e12456fe04225ff66bb349b9"
+  url "https://github.com/fyrsmithlabs/contextd/archive/refs/tags/v0.5.0.tar.gz"
+  sha256 "405c0664592c36666e8df24d054155e27a2de585c867c37890aebec470bf88fd"
 
   depends_on "go" => :build
   depends_on "onnxruntime"


### PR DESCRIPTION
Bumps the Homebrew formula to v0.5.0. The release pipeline's `Update Homebrew Formula` job (run 27831354722) computed this correctly but its push to `main` was rejected by branch protection (GH006 — PRs required), so this lands the same change via PR.

- `version` 0.4.0 → 0.5.0
- `url` → v0.5.0 source tarball
- `sha256` → `405c0664592c36666e8df24d054155e27a2de585c867c37890aebec470bf88fd` (sha256 of the v0.5.0 source tarball)

After merge, `brew upgrade fyrsmithlabs/contextd/contextd` will pick up v0.5.0.

Note: the release workflow should be updated to open a PR (or target an unprotected path) instead of pushing the formula directly to `main`, since this fails every release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)