### PR TITLE
feat(plugin): bootstrap in-repo contextd Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "contextd",
+  "version": "0.5.0",
+  "description": "Marketplace for contextd — cross-session memory, context persistence, and error-pattern tracking for AI agents.",
+  "owner": {
+    "name": "fyrsmithlabs",
+    "email": "dustinhendel@gmail.com",
+    "url": "https://github.com/fyrsmithlabs"
+  },
+  "plugins": [
+    {
+      "name": "contextd",
+      "source": "./plugins/contextd",
+      "description": "Cross-session memory, checkpoints, and error remediation for Claude Code, backed by the contextd MCP server.",
+      "version": "0.5.0",
+      "category": "productivity",
+      "author": {
+        "name": "fyrsmithlabs",
+        "email": "dustinhendel@gmail.com"
+      }
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ internal/embeddings/local_cache/
 
 # Local config and test artifacts
 .mcp.json
+# ...but keep the contextd plugin's bundled MCP server config
+!plugins/contextd/.mcp.json
 testagent
 
 # Test artifacts (not source code)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md - contextd
 
 **Status**: Active Development (Phase 6 complete)
-**Last Updated**: 2026-01-06
+**Last Updated**: 2026-06-19
 
 ---
 
@@ -44,7 +44,7 @@ Before ANY codebase exploration or task work:
 
 ## ⚠️ CRITICAL: Update Claude Plugin on Changes (Priority #3)
 
-**After ANY feature/fix/release, update the fyrsmithlabs/marketplace plugin.**
+**After ANY feature/fix/release, update the in-repo `contextd` plugin.**
 
 When these occur:
 - New feature added
@@ -53,9 +53,11 @@ When these occur:
 - New skills/commands/agents
 - MCP tool changes
 
-**Action:** Update `fyrsmithlabs/marketplace` repo to expose new capabilities to users. DO NOT skip this step.
+**Action:** Update the bundled `contextd` plugin under `plugins/contextd/` to expose new capabilities to users. DO NOT skip this step.
 
-**Plugin Location:** https://github.com/fyrsmithlabs/marketplace (contextd commands are prefixed with `contextd-`)
+**Plugin Location:** `plugins/contextd/` in this repository. The repo is itself a Claude Code plugin marketplace (`.claude-plugin/marketplace.json`, marketplace name `contextd`), so the plugin ships and versions alongside the core code rather than in a separate repo. See [Claude Code Plugin](#claude-code-plugin) below.
+
+> **Note:** The plugin previously lived in the external `fyrsmithlabs/marketplace` repo. It now lives in-repo so plugin and server stay in lockstep. When releasing, bump the version in both `VERSION`/`plugin.json`/`marketplace.json` together.
 
 **Required Order:**
 1. ✅ `mcp__contextd__memory_search` - Search past learnings/strategies first
@@ -299,7 +301,42 @@ internal/
 ├── logging/           # Zap + OTEL bridge
 └── telemetry/         # OpenTelemetry
 pkg/api/v1/            # Proto definitions (unused - simplified away)
+.claude-plugin/        # Marketplace manifest (marketplace name: contextd)
+plugins/contextd/      # In-repo Claude Code plugin (see "Claude Code Plugin")
 ```
+
+---
+
+## Claude Code Plugin
+
+The `contextd` Claude Code plugin lives **in this repo** under `plugins/contextd/`. The repository root is also a plugin marketplace (`.claude-plugin/marketplace.json`, name `contextd`), so the plugin is distributed and versioned alongside the server code instead of in a separate repo.
+
+### Layout
+
+```
+.claude-plugin/marketplace.json        # Marketplace "contextd" → lists the plugin
+plugins/contextd/
+├── .claude-plugin/plugin.json         # Plugin manifest (keep version in sync with VERSION)
+├── .mcp.json                          # Bundled `contextd --mcp` server (git-tracked via .gitignore negation)
+├── commands/                          # /contextd:checkpoint, remember, diagnose, resume, status, search
+├── skills/                            # using-contextd, cross-session-memory, checkpoint-workflow, error-remediation
+├── hooks/                             # hooks.json + defensive SessionStart script
+└── README.md
+```
+
+### Install
+
+```
+/plugin marketplace add fyrsmithlabs/contextd
+/plugin install contextd@contextd
+```
+
+### Rules for changes
+
+- **Keep versions in lockstep:** when bumping `VERSION`, also bump `plugins/contextd/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`.
+- **New MCP tool / command / skill?** Add or update the matching plugin component under `plugins/contextd/` in the same change (Priority #3).
+- **`.mcp.json` is git-tracked** here via a `.gitignore` negation (`!plugins/contextd/.mcp.json`); the root-level `.mcp.json` ignore is for local dev only — don't remove the negation.
+- **Validate** hooks with the plugin-dev `validate-hook-schema.sh`; keep manifests valid JSON.
 
 ---
 

--- a/plugins/contextd/.claude-plugin/plugin.json
+++ b/plugins/contextd/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "contextd",
+  "version": "0.5.0",
+  "description": "Cross-session memory, context checkpoints, semantic search, and error remediation for Claude Code, backed by the contextd MCP server.",
+  "author": {
+    "name": "fyrsmithlabs",
+    "email": "dustinhendel@gmail.com",
+    "url": "https://github.com/fyrsmithlabs"
+  },
+  "homepage": "https://github.com/fyrsmithlabs/contextd",
+  "repository": "https://github.com/fyrsmithlabs/contextd",
+  "license": "MIT",
+  "keywords": [
+    "memory",
+    "context",
+    "checkpoint",
+    "remediation",
+    "semantic-search",
+    "mcp",
+    "reasoningbank"
+  ]
+}

--- a/plugins/contextd/.mcp.json
+++ b/plugins/contextd/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "contextd": {
+      "command": "contextd",
+      "args": ["--mcp"],
+      "env": {
+        "CONTEXTD_VECTORSTORE_PROVIDER": "chromem"
+      }
+    }
+  }
+}

--- a/plugins/contextd/README.md
+++ b/plugins/contextd/README.md
@@ -1,0 +1,65 @@
+# contextd plugin for Claude Code
+
+Cross-session memory, context checkpoints, semantic code search, and error
+remediation for Claude Code — backed by the [contextd](https://github.com/fyrsmithlabs/contextd)
+MCP server.
+
+## What you get
+
+**Skills** (auto-activate based on context):
+
+| Skill | Activates when |
+|-------|----------------|
+| `using-contextd` | Starting a session / non-trivial task |
+| `cross-session-memory` | Searching for or recording reusable learnings |
+| `checkpoint-workflow` | Preserving or resuming session state |
+| `error-remediation` | An error, failed build, or failing test appears |
+
+**Commands**:
+
+| Command | Purpose |
+|---------|---------|
+| `/contextd:checkpoint` | Save a resumable context checkpoint |
+| `/contextd:remember` | Record a learning into memory |
+| `/contextd:diagnose` | Diagnose an error and find known fixes |
+| `/contextd:resume` | List and resume from a checkpoint |
+| `/contextd:status` | Show memories, checkpoints, and project context |
+| `/contextd:search` | Search memories, remediations, and code |
+
+**MCP server**: bundled `.mcp.json` launches `contextd --mcp`, exposing the full
+tool set (memory, checkpoint, remediation, semantic search, context-folding,
+conversation indexing, reflection).
+
+**Hook**: a defensive `SessionStart` hook that reminds Claude to use contextd
+when the binary is present, and no-ops silently when it isn't.
+
+## Prerequisites
+
+The `contextd` binary must be on `PATH` for the MCP server to start:
+
+```bash
+# Homebrew
+brew tap fyrsmithlabs/tap && brew install contextd
+
+# or build from source
+go build -o contextd ./cmd/contextd
+```
+
+## Install
+
+This repository is itself a plugin marketplace named `contextd`.
+
+```
+/plugin marketplace add fyrsmithlabs/contextd
+/plugin install contextd@contextd
+```
+
+For local development against a checkout, point the marketplace at the repo root
+(which contains `.claude-plugin/marketplace.json`).
+
+## Configuration
+
+The bundled MCP server defaults to the embedded `chromem` vector store. Override
+via environment variables in `.mcp.json` or your contextd config — for example
+`CONTEXTD_VECTORSTORE_PROVIDER=qdrant`. See the
+[contextd docs](https://github.com/fyrsmithlabs/contextd) for the full list.

--- a/plugins/contextd/commands/checkpoint.md
+++ b/plugins/contextd/commands/checkpoint.md
@@ -1,0 +1,20 @@
+---
+name: checkpoint
+description: Save a context checkpoint of the current session so it can be resumed later.
+argument-hint: "[optional summary]"
+---
+
+# /contextd:checkpoint
+
+Save a checkpoint of the current session using the contextd `checkpoint_save` MCP tool.
+
+Steps:
+
+1. Build a resumable summary. If the user supplied text in `$ARGUMENTS`, use it as the summary; otherwise auto-generate one from the recent conversation covering:
+   - **What was done** — the concrete state reached so far.
+   - **What's next** — the immediate next step(s).
+   - **Open questions / blockers** — anything unresolved.
+2. Call `checkpoint_save` with that summary.
+3. Report the checkpoint id and a one-line confirmation of what was saved.
+
+If the contextd MCP server is unavailable, tell the user the checkpoint could not be saved and suggest verifying the `contextd` MCP server is running (`contextd --mcp`).

--- a/plugins/contextd/commands/checkpoint.md
+++ b/plugins/contextd/commands/checkpoint.md
@@ -1,6 +1,5 @@
 ---
-name: checkpoint
-description: Save a context checkpoint of the current session so it can be resumed later.
+description: Save a resumable context checkpoint of this session
 argument-hint: "[optional summary]"
 ---
 

--- a/plugins/contextd/commands/diagnose.md
+++ b/plugins/contextd/commands/diagnose.md
@@ -1,0 +1,19 @@
+---
+name: diagnose
+description: Diagnose an error and search contextd for a known fix.
+argument-hint: "<error message or description>"
+---
+
+# /contextd:diagnose
+
+Diagnose the error in `$ARGUMENTS` (or, if empty, the most recent error in the conversation) using contextd.
+
+Steps:
+
+1. Call `troubleshoot_diagnose` with the error to get AI-powered analysis of the likely cause.
+2. Call `remediation_search` with the stable part of the error signature to find any fix that worked before.
+3. Present:
+   - The diagnosis (category + likely cause).
+   - Any matching known remediation, clearly marked as a prior fix.
+   - A recommended next step.
+4. After the user applies a fix and confirms it works, offer to record it with `remediation_record` so the fix is reused next time.

--- a/plugins/contextd/commands/diagnose.md
+++ b/plugins/contextd/commands/diagnose.md
@@ -1,6 +1,5 @@
 ---
-name: diagnose
-description: Diagnose an error and search contextd for a known fix.
+description: Diagnose an error and find a known contextd fix
 argument-hint: "<error message or description>"
 ---
 

--- a/plugins/contextd/commands/remember.md
+++ b/plugins/contextd/commands/remember.md
@@ -1,6 +1,5 @@
 ---
-name: remember
-description: Record a learning or insight from the current session into contextd memory.
+description: Record a learning from this session into contextd memory
 argument-hint: "[what to remember]"
 ---
 

--- a/plugins/contextd/commands/remember.md
+++ b/plugins/contextd/commands/remember.md
@@ -1,0 +1,20 @@
+---
+name: remember
+description: Record a learning or insight from the current session into contextd memory.
+argument-hint: "[what to remember]"
+---
+
+# /contextd:remember
+
+Record a durable learning into the contextd ReasoningBank using the `memory_record` MCP tool.
+
+Steps:
+
+1. Determine the content to record:
+   - If `$ARGUMENTS` is provided, record that.
+   - Otherwise, distill the key insight from the recent conversation.
+2. Capture the **why**, not just the what — include the approach that worked, rejected alternatives, the deciding tradeoff, and any consequences/gotchas.
+3. Call `memory_record` with the distilled content.
+4. Confirm what was stored in one or two lines.
+
+Do not record secrets or credentials. Skip recording if the insight is already obvious from the code or docs.

--- a/plugins/contextd/commands/resume.md
+++ b/plugins/contextd/commands/resume.md
@@ -1,6 +1,5 @@
 ---
-name: resume
-description: List contextd checkpoints and resume from one.
+description: List contextd checkpoints and resume from one
 argument-hint: "[checkpoint id]"
 ---
 

--- a/plugins/contextd/commands/resume.md
+++ b/plugins/contextd/commands/resume.md
@@ -1,0 +1,16 @@
+---
+name: resume
+description: List contextd checkpoints and resume from one.
+argument-hint: "[checkpoint id]"
+---
+
+# /contextd:resume
+
+Resume work from a previously saved contextd checkpoint.
+
+Steps:
+
+1. If `$ARGUMENTS` contains a checkpoint id, skip to step 3 with that id.
+2. Otherwise call `checkpoint_list` and show the available checkpoints (id, summary, timestamp). Ask the user which one to resume.
+3. Call `checkpoint_resume` with the chosen id. Default to the `context` level unless the user asks for `summary` (quick reorientation) or `full` (deep resumption after a long gap).
+4. Summarize the restored state and state the immediate next step so work can continue.

--- a/plugins/contextd/commands/search.md
+++ b/plugins/contextd/commands/search.md
@@ -1,0 +1,18 @@
+---
+name: search
+description: Search contextd across memories, remediations, and indexed code.
+argument-hint: "<query>"
+---
+
+# /contextd:search
+
+Search contextd for anything relevant to `$ARGUMENTS`.
+
+Steps:
+
+1. Run these searches for the query:
+   - `memory_search` — past strategies and decisions.
+   - `remediation_search` — known error fixes.
+   - `semantic_search` (with `project_path: "."`) — relevant code in this repository.
+2. Merge and present the most relevant hits, grouped by source (Memories / Remediations / Code), each with a one-line relevance note.
+3. If nothing relevant is found, say so plainly rather than padding with weak matches.

--- a/plugins/contextd/commands/search.md
+++ b/plugins/contextd/commands/search.md
@@ -1,6 +1,5 @@
 ---
-name: search
-description: Search contextd across memories, remediations, and indexed code.
+description: Search contextd memories, remediations, and code
 argument-hint: "<query>"
 ---
 

--- a/plugins/contextd/commands/status.md
+++ b/plugins/contextd/commands/status.md
@@ -1,6 +1,5 @@
 ---
-name: status
-description: Show contextd session info — memories, checkpoints, and tenant/project context.
+description: Show contextd memories, checkpoints, and project context
 ---
 
 # /contextd:status

--- a/plugins/contextd/commands/status.md
+++ b/plugins/contextd/commands/status.md
@@ -1,0 +1,20 @@
+---
+name: status
+description: Show contextd session info — memories, checkpoints, and tenant/project context.
+---
+
+# /contextd:status
+
+Report the current contextd state for this session.
+
+Steps:
+
+1. Call `checkpoint_list` to get available checkpoints (count + most recent).
+2. Run a broad `memory_search` for the current project to gauge how many relevant memories exist.
+3. Summarize:
+   - Tenant / project context contextd is operating under (auto-derived from the repository).
+   - Number of checkpoints and the most recent one.
+   - Whether relevant memories exist for this project.
+4. If the contextd MCP server is unavailable, say so and suggest checking that `contextd --mcp` is running.
+
+Keep the output to a compact status block.

--- a/plugins/contextd/hooks/hooks.json
+++ b/plugins/contextd/hooks/hooks.json
@@ -1,14 +1,17 @@
 {
-  "SessionStart": [
-    {
-      "matcher": "*",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-start.sh",
-          "timeout": 10
-        }
-      ]
-    }
-  ]
+  "description": "contextd lifecycle hooks for Claude Code",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-start.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugins/contextd/hooks/hooks.json
+++ b/plugins/contextd/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "SessionStart": [
+    {
+      "matcher": "*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-start.sh",
+          "timeout": 10
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/contextd/hooks/scripts/session-start.sh
+++ b/plugins/contextd/hooks/scripts/session-start.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# contextd plugin — SessionStart hook.
+#
+# Reminds Claude to use contextd's cross-session memory and checkpoint tools at
+# the start of a session. Defensive by design: if the contextd binaries are not
+# installed, it exits 0 silently so it never blocks or breaks a session.
+set -euo pipefail
+
+# No contextd binary present → nothing to do.
+if ! command -v contextd >/dev/null 2>&1 && ! command -v ctxd >/dev/null 2>&1; then
+  exit 0
+fi
+
+# SessionStart hooks may emit additionalContext as JSON on stdout.
+cat <<'JSON'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "contextd is available. Before exploring code, run semantic_search and memory_search. Record durable learnings with memory_record and save context with checkpoint_save when nearing context limits."
+  }
+}
+JSON

--- a/plugins/contextd/skills/checkpoint-workflow/SKILL.md
+++ b/plugins/contextd/skills/checkpoint-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: checkpoint-workflow
-description: Use to preserve and restore session state — when context is getting full (approaching ~70%), before a long-running task, before /clear, or when resuming earlier work. Triggers on "save my progress", "pick up where we left off", "checkpoint this", or running low on context. Covers checkpoint_save, checkpoint_list, and checkpoint_resume.
+description: This skill should be used to preserve or restore session state. It triggers when the user says "save my progress", "checkpoint this", "pick up where we left off", or "resume", before /clear, before a long-running task, or when context usage approaches ~70%. Covers checkpoint_save, checkpoint_list, and checkpoint_resume.
 version: 0.5.0
 ---
 
@@ -47,5 +47,5 @@ Choose the resume **level** to match the need:
 
 ## Tips
 
-- Pair with `cross-session-memory`: checkpoints capture *this* session's state; memories capture *reusable* insight. Record durable learnings as memories before they're lost to a checkpoint you may never reopen.
+- Pair with `cross-session-memory`: checkpoints capture *this* session's state; memories capture *reusable* insight. Record durable learnings as memories before they are lost to a checkpoint that may never be reopened.
 - Auto-checkpoint on `/clear` and auto-resume on start can be enabled via contextd hooks/config (`CONTEXTD_AUTO_CHECKPOINT_ON_CLEAR`, `CONTEXTD_AUTO_RESUME_ON_START`, `CONTEXTD_CHECKPOINT_THRESHOLD`).

--- a/plugins/contextd/skills/checkpoint-workflow/SKILL.md
+++ b/plugins/contextd/skills/checkpoint-workflow/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: checkpoint-workflow
+description: Use to preserve and restore session state — when context is getting full (approaching ~70%), before a long-running task, before /clear, or when resuming earlier work. Triggers on "save my progress", "pick up where we left off", "checkpoint this", or running low on context. Covers checkpoint_save, checkpoint_list, and checkpoint_resume.
+version: 0.5.0
+---
+
+# Checkpoint Workflow
+
+## Overview
+
+Checkpoints snapshot the working context so a session can be resumed later — after `/clear`, in a new session, or after a long-running task. This is context **preservation**, distinct from memory (reusable strategies).
+
+## When to checkpoint
+
+- Context usage approaching ~70%.
+- Before a long or risky operation that might exhaust context.
+- Before `/clear` or ending a session with unfinished work.
+- When the user asks to save progress.
+
+## Saving
+
+```
+checkpoint_save(summary, ...)
+```
+
+Write a summary that lets a future session resume cold:
+- **What was done** — the concrete state reached.
+- **What's next** — the immediate next step(s).
+- **Open questions / blockers** — anything unresolved.
+
+A vague summary ("working on the feature") defeats the purpose.
+
+## Resuming
+
+```
+checkpoint_list()                  # find the relevant checkpoint
+checkpoint_resume(id, level)       # restore it
+```
+
+Choose the resume **level** to match the need:
+
+| Level | Restores | Use when |
+|-------|----------|----------|
+| `summary` | Just the summary | Quick reorientation |
+| `context` | Summary + key context | Continuing the same task |
+| `full` | Everything captured | Deep resumption after a long gap |
+
+## Tips
+
+- Pair with `cross-session-memory`: checkpoints capture *this* session's state; memories capture *reusable* insight. Record durable learnings as memories before they're lost to a checkpoint you may never reopen.
+- Auto-checkpoint on `/clear` and auto-resume on start can be enabled via contextd hooks/config (`CONTEXTD_AUTO_CHECKPOINT_ON_CLEAR`, `CONTEXTD_AUTO_RESUME_ON_START`, `CONTEXTD_CHECKPOINT_THRESHOLD`).

--- a/plugins/contextd/skills/cross-session-memory/SKILL.md
+++ b/plugins/contextd/skills/cross-session-memory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cross-session-memory
-description: Use when starting a task to check for prior solutions, and when finishing one to record what was learned. Triggers on "have we solved this before", reusing a past approach, capturing a design decision, or any non-trivial task whose insight should survive the session. Covers memory_search, memory_record, memory_feedback, and memory_outcome.
+description: This skill should be used when starting a task to check for prior solutions, or when finishing one to record a learning. It triggers when the user says "have we solved this before", "remember this", "record what we learned", reuses a past approach, or captures a design decision worth surviving the session. Covers memory_search, memory_record, memory_feedback, and memory_outcome.
 version: 0.5.0
 ---
 

--- a/plugins/contextd/skills/cross-session-memory/SKILL.md
+++ b/plugins/contextd/skills/cross-session-memory/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: cross-session-memory
+description: Use when starting a task to check for prior solutions, and when finishing one to record what was learned. Triggers on "have we solved this before", reusing a past approach, capturing a design decision, or any non-trivial task whose insight should survive the session. Covers memory_search, memory_record, memory_feedback, and memory_outcome.
+version: 0.5.0
+---
+
+# Cross-Session Memory
+
+## Overview
+
+contextd's ReasoningBank stores **reusable strategies and decisions** with confidence scoring. The loop is simple: search before solving, record after solving, and give feedback so confidence stays calibrated.
+
+## The loop
+
+### 1. Search before assuming (task start)
+
+```
+memory_search(project_id, query)
+```
+
+Ask "have I solved something like this before?" before re-deriving an approach. Always search before assuming a problem is novel.
+
+### 2. Record after solving (task completion)
+
+```
+memory_record(project_id, content, ...)
+```
+
+Capture the **why**, not just the what. A good memory includes:
+- The problem and the approach that worked
+- Rejected alternatives and the tradeoff that decided it
+- Consequences / gotchas to watch for
+
+### 3. Report outcomes and feedback
+
+- `memory_outcome` — after acting on a memory, report whether the task succeeded. This is the reinforcement signal.
+- `memory_feedback` — rate a specific memory as helpful or not, adjusting its confidence.
+
+### 4. Consolidate (periodically)
+
+`memory_consolidate` merges similar memories into refined summaries so the bank stays sharp instead of accumulating near-duplicates.
+
+## What makes a good memory
+
+| Good | Avoid |
+|------|-------|
+| "Use payload isolation, not filesystem, for multi-tenant vectorstore — avoids N collections; rejected per-tenant DB because of open-file limits." | "Fixed the bug." |
+| Decision + rejected alternative + consequence | Restating code that's already in the diff |
+
+## When NOT to record
+
+- Information already obvious from the code or docs.
+- Secrets or credentials (contextd scrubs responses, but don't author them into memories).

--- a/plugins/contextd/skills/error-remediation/SKILL.md
+++ b/plugins/contextd/skills/error-remediation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: error-remediation
-description: Use whenever an error, exception, failed build, or failing test is encountered. Triggers on stack traces, compiler/linter errors, CI failures, panics, or "why is this failing". Covers troubleshoot_diagnose, remediation_search, remediation_record, and remediation_feedback so fixes are matched to past solutions and saved for next time.
+description: This skill should be used whenever an error, exception, failed build, failing test, stack trace, compiler/linter error, CI failure, or panic appears, or when the user asks "why is this failing" or "how do I fix this". Covers troubleshoot_diagnose, remediation_search, remediation_record, and remediation_feedback to match errors to past fixes and record new ones.
 version: 0.5.0
 ---
 
@@ -26,7 +26,7 @@ Get AI-powered analysis of the error first — it categorizes the failure and su
 remediation_search(query)
 ```
 
-Paste the salient part of the error message. If contextd has seen it, you get the fix that worked before — don't re-derive it.
+Pass the salient part of the error message. If contextd has seen it, it returns the fix that worked before — do not re-derive it.
 
 ### 3. Record the fix
 

--- a/plugins/contextd/skills/error-remediation/SKILL.md
+++ b/plugins/contextd/skills/error-remediation/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: error-remediation
+description: Use whenever an error, exception, failed build, or failing test is encountered. Triggers on stack traces, compiler/linter errors, CI failures, panics, or "why is this failing". Covers troubleshoot_diagnose, remediation_search, remediation_record, and remediation_feedback so fixes are matched to past solutions and saved for next time.
+version: 0.5.0
+---
+
+# Error Remediation
+
+## Overview
+
+contextd tracks **error → fix patterns**. When something breaks, check whether this exact failure was fixed before, diagnose it, fix it, then record the fix so the next occurrence is instant.
+
+## The flow
+
+### 1. Diagnose
+
+```
+troubleshoot_diagnose(error)
+```
+
+Get AI-powered analysis of the error first — it categorizes the failure and suggests likely causes.
+
+### 2. Search for a known fix
+
+```
+remediation_search(query)
+```
+
+Paste the salient part of the error message. If contextd has seen it, you get the fix that worked before — don't re-derive it.
+
+### 3. Record the fix
+
+After resolving it:
+
+```
+remediation_record(error, fix, ...)
+```
+
+Capture:
+- The **error signature** (the stable part of the message, not volatile paths/timestamps).
+- The **fix** that actually worked.
+- Any root cause worth noting.
+
+### 4. Feedback
+
+`remediation_feedback` — rate whether a suggested fix actually helped, so its confidence stays accurate.
+
+## Good vs. weak remediations
+
+| Good | Weak |
+|------|------|
+| `ErrMissingTenant` on Search → wrap ctx with `ContextWithTenant` before calling the store; fail-closed is intentional. | "It works now." |
+| Stable error signature + concrete fix + cause | Logging the full transient stack trace as the signature |
+
+## When NOT to record
+
+- One-off typos with no reusable pattern.
+- Environment-specific noise unlikely to recur.

--- a/plugins/contextd/skills/using-contextd/SKILL.md
+++ b/plugins/contextd/skills/using-contextd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-contextd
-description: Use at the start of any coding or research session to establish the contextd workflow — cross-session memory, checkpoints, semantic search, and error remediation. Triggers when the user mentions remembering past work, resuming a session, "what did we do before", persistent memory, or when starting a non-trivial task that could benefit from prior learnings.
+description: This skill should be used at the start of a coding or research session, or when the user says "what did we do before", "remember", "resume", mentions persistent or cross-session memory, or begins a non-trivial task that could reuse prior learnings. It establishes the contextd workflow — run semantic_search and memory_search before exploring code — and points to the cross-session-memory, checkpoint-workflow, and error-remediation skills.
 version: 0.5.0
 ---
 

--- a/plugins/contextd/skills/using-contextd/SKILL.md
+++ b/plugins/contextd/skills/using-contextd/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: using-contextd
+description: Use at the start of any coding or research session to establish the contextd workflow — cross-session memory, checkpoints, semantic search, and error remediation. Triggers when the user mentions remembering past work, resuming a session, "what did we do before", persistent memory, or when starting a non-trivial task that could benefit from prior learnings.
+version: 0.5.0
+---
+
+# Using contextd
+
+## Overview
+
+contextd is an MCP server that gives Claude Code **persistent memory across sessions**. It learns from successes and failures, saves context for resumption, tracks error fixes, and provides semantic code search. Every response is scrubbed for secrets with gitleaks.
+
+This skill establishes the mental model. Three companion skills cover the workflows:
+- `cross-session-memory` — the learning loop (search before solving, record after)
+- `checkpoint-workflow` — context preservation and resumption
+- `error-remediation` — matching and recording error fixes
+
+## The contextd tools
+
+| Group | Tools | Use for |
+|-------|-------|---------|
+| Memory | `memory_search`, `memory_record`, `memory_feedback`, `memory_outcome`, `memory_consolidate` | Reusable strategies and design decisions |
+| Checkpoint | `checkpoint_save`, `checkpoint_list`, `checkpoint_resume` | Saving/restoring session state |
+| Remediation | `remediation_search`, `remediation_record`, `remediation_feedback` | Concrete error → fix pairs |
+| Search | `semantic_search`, `repository_index`, `repository_search` | Finding code by meaning (with grep fallback) |
+| Diagnosis | `troubleshoot_diagnose` | AI-powered analysis of an error |
+
+## Pre-flight (do this first)
+
+Before exploring a codebase or starting a task:
+
+1. `semantic_search(query, project_path: ".")` — find relevant code by meaning before falling back to Read/Grep/Glob.
+2. `memory_search(project_id, query)` — check whether this problem has been solved before.
+
+These are cheap and usually save far more work than they cost.
+
+## When NOT to use contextd
+
+- Trivial one-line edits with no reusable insight.
+- When the user explicitly wants a clean slate with no prior context.
+
+## Tenant context
+
+contextd derives the tenant/project automatically from the repository (e.g. the Git remote). No manual configuration is required for normal use.


### PR DESCRIPTION
## Summary

Bootstraps the **`contextd` Claude Code plugin** as an in-repo component, using Anthropic's official `plugin-dev` toolkit conventions. The repository now doubles as a plugin marketplace named `contextd`, matching the `contextd@contextd` entry already present in `.claude/settings.json`. The plugin ships and versions alongside the server code instead of in a separate repo.

## What's included

```
.claude-plugin/marketplace.json        # marketplace "contextd" → lists the plugin
plugins/contextd/
├── .claude-plugin/plugin.json         # plugin manifest (v0.5.0)
├── .mcp.json                          # bundled `contextd --mcp` server
├── commands/                          # /contextd: checkpoint, remember, diagnose, resume, status, search
├── skills/                            # using-contextd, cross-session-memory, checkpoint-workflow, error-remediation
├── hooks/                             # hooks.json + defensive SessionStart script
└── README.md
```

- **4 skills** teach when to use contextd's MCP tools; descriptions are third-person with concrete trigger phrases so Claude auto-activates them.
- **6 commands** written as instructions-for-Claude (name derives from filename → `/contextd:checkpoint`, etc.).
- **SessionStart hook** is defensive — exits 0 silently when the `contextd`/`ctxd` binary is absent, so it never blocks a session.
- **MCP server** launches `contextd --mcp` (binary resolved on `PATH`; not bundled, so no `${CLAUDE_PLUGIN_ROOT}`).
- **CLAUDE.md** updated: Priority #3 now points to the in-repo plugin, plus a new "Claude Code Plugin" section documenting layout, install, and the rule to keep `VERSION` / `plugin.json` / `marketplace.json` in lockstep.
- **.gitignore**: added `!plugins/contextd/.mcp.json` so the plugin's MCP config is tracked (the root `.mcp.json` ignore is for local dev only).

## Validation

Built and validated against the official `plugin-dev` toolkit:

- `claude plugin validate plugins/contextd` → ✅ passed
- `claude plugin validate .` (marketplace) → ✅ passed
- Live end-to-end install (`marketplace add ./` → `install contextd@contextd` → `details`) → ✅ enabled, all components load: 4 skills, 6 commands, 1 SessionStart hook, 1 MCP server.

Notable fix during review: a plugin `hooks.json` requires a top-level `{"hooks": {...}}` wrapper (distinct from the settings format), which `claude plugin validate` caught.

## Install

```
/plugin marketplace add fyrsmithlabs/contextd
/plugin install contextd@contextd
```

> Note: requires the `contextd` binary on `PATH` for the MCP server to start (`brew install fyrsmithlabs/tap/contextd` or build from source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dx7G4kSYGsGi2SFmkhs8QK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dx7G4kSYGsGi2SFmkhs8QK)_