### PR TITLE
feat(mcp): full MCP surface — Resources, Prompts, Streamable HTTP, swarm notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **MCP Resources** — read-only, JSON, secret-scrubbed resources exposing memories, checkpoints, and remediations. Includes a `contextd://help` resource plus templates for collections and by-id lookups (and `remediations{?query}` search). Tenant-scoped via the `project_id` in the URI and fail-closed when tenant context is missing.
+- **MCP Prompts** — six workflow prompts auto-available to any MCP host: `contextd_checkpoint`, `contextd_remember`, `contextd_diagnose`, `contextd_resume`, `contextd_status`, `contextd_search`.
+- **Streamable HTTP transport** for remote MCP hosting via `--mcp-http-port` / `--mcp-http-host`. A dedicated Echo server exposes `/mcp` and `/health`, separate from the REST `--http-port` API.
+- **Bearer-token auth** for the HTTP MCP endpoint via `--mcp-http-token` / `CONTEXTD_MCP_HTTP_TOKEN`.
+- **MCP client primitives** — logging with progress on `repository_index`, and elicitation in `checkpoint_resume` (asks which checkpoint when none is given).
+- **Agent-swarm notifications** — `resources/subscribe` + `resources/updated` broadcast when shared memories, checkpoints, or remediations are recorded (design doc: `docs/spec/mcp-protocol/notifications-agent-swarm.md`).
+
+### Changed
+- **MCP serverInfo name** changed from `contextd-v2` to `contextd`.
+
 ## [0.5.0] - 2026-06-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -368,6 +368,76 @@ ContextD exposes 25 tools to Claude Code, organized by category:
 
 ---
 
+## MCP Resources
+
+Beyond tools, contextd exposes read-only **MCP resources**. Resource contents are JSON, secret-scrubbed, and tenant-scoped via the `project_id` embedded in the URI.
+
+- `contextd://help` - server overview and usage hints
+- `contextd://{project_id}/memories` - list memories for a project
+- `contextd://{project_id}/memory/{id}` - a single memory
+- `contextd://{project_id}/checkpoints` - list checkpoints
+- `contextd://{project_id}/checkpoint/{id}` - a single checkpoint
+- `contextd://{project_id}/remediation/{id}` - a single remediation
+- `contextd://{project_id}/remediations{?query}` - search remediations
+
+Example:
+
+```
+contextd://contextd/memory/abc123
+```
+
+See [docs/CONTEXTD.md](docs/CONTEXTD.md) for the full resource list and schemas.
+
+---
+
+## MCP Prompts
+
+ContextD ships six workflow prompts that mirror the plugin commands:
+
+| Prompt | Purpose |
+|--------|---------|
+| `contextd_checkpoint` | Save a session checkpoint |
+| `contextd_remember` | Record a learning or insight |
+| `contextd_diagnose` | Diagnose an error |
+| `contextd_resume` | Resume from a checkpoint |
+| `contextd_status` | Show contextd status |
+| `contextd_search` | Search memories and remediations |
+
+---
+
+## Remote Hosting (Streamable HTTP)
+
+The MCP server runs over **stdio** (default) or **Streamable HTTP** for remote hosting:
+
+```bash
+# stdio (local, used by Claude Code)
+contextd --mcp
+
+# Streamable HTTP (remote)
+contextd --mcp-http-port 9095 [--mcp-http-host 0.0.0.0]
+```
+
+The HTTP transport is served by a dedicated Echo server (separate from the `--http-port` REST API), exposing `/mcp` and `/health`.
+
+**Optional bearer auth:** set `--mcp-http-token` or `CONTEXTD_MCP_HTTP_TOKEN`. If unset, the endpoint is unauthenticated (localhost/testing only) and logs a warning.
+
+A client connects by POSTing an `initialize` request to `/mcp`:
+
+```bash
+curl -X POST http://host:9095/mcp \
+  -H "Authorization: Bearer $CONTEXTD_MCP_HTTP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+```
+
+Omit the `Authorization` header when no token is configured.
+
+### Agent Swarms
+
+Multiple agents can connect to one HTTP-hosted contextd and receive `resources/updated` notifications when shared memories, checkpoints, or remediations change. See [docs/spec/mcp-protocol/notifications-agent-swarm.md](docs/spec/mcp-protocol/notifications-agent-swarm.md).
+
+---
+
 ## How It Works
 
 ```

--- a/cmd/contextd/main.go
+++ b/cmd/contextd/main.go
@@ -75,6 +75,7 @@ func run() error {
 	mcpMode := flag.Bool("mcp", false, "run in MCP mode (stdio transport)")
 	mcpHTTPPort := flag.Int("mcp-http-port", 0, "run the MCP server over the Streamable HTTP transport on this port (separate from --http-port REST API)")
 	mcpHTTPHost := flag.String("mcp-http-host", "localhost", "host to bind the MCP Streamable HTTP server")
+	mcpHTTPToken := flag.String("mcp-http-token", "", "bearer token required on the MCP Streamable HTTP endpoint (or set CONTEXTD_MCP_HTTP_TOKEN); empty serves unauthenticated for localhost/testing")
 	downloadModels := flag.Bool("download-models", false, "download embedding models and exit (for airgap/container builds)")
 	flag.Parse()
 
@@ -587,9 +588,14 @@ func run() error {
 		// Run MCP server in background goroutine (no longer blocks).
 		mcpErrChan = make(chan error, 1)
 		if mcpHTTPEnabled {
+			mcpToken := *mcpHTTPToken
+			if mcpToken == "" {
+				mcpToken = os.Getenv("CONTEXTD_MCP_HTTP_TOKEN")
+			}
 			httpCfg := mcp.StreamableHTTPConfig{
-				Host: *mcpHTTPHost,
-				Port: *mcpHTTPPort,
+				Host:  *mcpHTTPHost,
+				Port:  *mcpHTTPPort,
+				Token: mcpToken,
 			}
 			logger.Info(ctx, "MCP server initialized, starting streamable HTTP transport",
 				zap.String("mcp_http_host", *mcpHTTPHost),

--- a/cmd/contextd/main.go
+++ b/cmd/contextd/main.go
@@ -73,6 +73,8 @@ func run() error {
 	httpHost := flag.String("http-host", "", "HTTP server host (overrides config, default: localhost)")
 	noHTTP := flag.Bool("no-http", false, "disable HTTP server (allows multiple instances)")
 	mcpMode := flag.Bool("mcp", false, "run in MCP mode (stdio transport)")
+	mcpHTTPPort := flag.Int("mcp-http-port", 0, "run the MCP server over the Streamable HTTP transport on this port (separate from --http-port REST API)")
+	mcpHTTPHost := flag.String("mcp-http-host", "localhost", "host to bind the MCP Streamable HTTP server")
 	downloadModels := flag.Bool("download-models", false, "download embedding models and exit (for airgap/container builds)")
 	flag.Parse()
 
@@ -543,7 +545,10 @@ func run() error {
 	// ============================================================================
 	var mcpServer *mcp.Server
 	var mcpErrChan chan error
-	if *mcpMode {
+	// MCP runs over stdio (--mcp) or Streamable HTTP (--mcp-http-port). Either
+	// flag builds and starts the MCP server.
+	mcpHTTPEnabled := *mcpHTTPPort > 0
+	if *mcpMode || mcpHTTPEnabled {
 		// MCP mode requires all services
 		if checkpointSvc == nil || remediationSvc == nil || repositorySvc == nil ||
 			troubleshootSvc == nil || reasoningbankSvc == nil {
@@ -579,16 +584,32 @@ func run() error {
 		}
 		defer mcpServer.Close()
 
-		logger.Info(ctx, "MCP server initialized, starting stdio transport")
-
-		// Run MCP server in background goroutine (no longer blocks)
+		// Run MCP server in background goroutine (no longer blocks).
 		mcpErrChan = make(chan error, 1)
-		go func() {
-			if err := mcpServer.Run(ctx); err != nil {
-				mcpErrChan <- fmt.Errorf("MCP server error: %w", err)
+		if mcpHTTPEnabled {
+			httpCfg := mcp.StreamableHTTPConfig{
+				Host: *mcpHTTPHost,
+				Port: *mcpHTTPPort,
 			}
-			close(mcpErrChan)
-		}()
+			logger.Info(ctx, "MCP server initialized, starting streamable HTTP transport",
+				zap.String("mcp_http_host", *mcpHTTPHost),
+				zap.Int("mcp_http_port", *mcpHTTPPort),
+			)
+			go func() {
+				if err := mcpServer.RunHTTP(ctx, httpCfg); err != nil {
+					mcpErrChan <- fmt.Errorf("MCP HTTP server error: %w", err)
+				}
+				close(mcpErrChan)
+			}()
+		} else {
+			logger.Info(ctx, "MCP server initialized, starting stdio transport")
+			go func() {
+				if err := mcpServer.Run(ctx); err != nil {
+					mcpErrChan <- fmt.Errorf("MCP server error: %w", err)
+				}
+				close(mcpErrChan)
+			}()
+		}
 	}
 
 	// Log service availability summary

--- a/docs/CONTEXTD.md
+++ b/docs/CONTEXTD.md
@@ -91,6 +91,41 @@ go build -o contextd ./cmd/contextd
 
 ---
 
+## MCP Resources
+
+Resources expose contextd state as read-only, JSON MCP resources. All resource
+content is secret-scrubbed (gitleaks) before return and tenant-scoped by the
+`project_id` embedded in the URI. Resources fail-closed: a missing or invalid
+project returns an error rather than another tenant's data or empty results.
+
+| Resource URI | Purpose |
+|--------------|---------|
+| `contextd://help` | Documents the `contextd://` URI scheme |
+| `contextd://{project_id}/memories` | Recent memories (collection) |
+| `contextd://{project_id}/memory/{id}` | A single memory |
+| `contextd://{project_id}/checkpoints` | Checkpoint list |
+| `contextd://{project_id}/checkpoint/{id}` | A single checkpoint |
+| `contextd://{project_id}/remediation/{id}` | A single remediation |
+| `contextd://{project_id}/remediations{?query}` | Remediation search (`query` required) |
+
+---
+
+## MCP Prompts
+
+Prompts are static workflow templates that mirror the bundled slash commands,
+guiding an agent through a common contextd task.
+
+| Prompt | Argument | Purpose |
+|--------|----------|---------|
+| `contextd_checkpoint` | `summary` (optional) | Save a resumable checkpoint |
+| `contextd_remember` | `content` (optional) | Record a learning |
+| `contextd_diagnose` | `error` (required) | Diagnose an error and find a known fix |
+| `contextd_resume` | `checkpoint_id` (optional) | List/resume a checkpoint |
+| `contextd_status` | _(none)_ | Show memories/checkpoints/project status |
+| `contextd_search` | `query` (required) | Search memories/remediations/code |
+
+---
+
 ## Configuration
 
 ### Environment Variables
@@ -143,24 +178,55 @@ server:
 
 ## Running Modes
 
-### MCP Mode (Claude Code integration)
+The MCP server identifies itself as `contextd` (the `serverInfo` name) over
+either of two transports.
+
+### MCP Mode — stdio (Claude Code integration)
 
 ```bash
 contextd --mcp
 ```
 
-Runs as stdio MCP server for Claude Code integration.
+Runs as a stdio MCP server for local Claude Code integration.
 
-### HTTP Mode (standalone)
+### MCP Mode — Streamable HTTP (remote hosting)
+
+```bash
+contextd --mcp-http-port 9095            # optionally --mcp-http-host 0.0.0.0
+```
+
+Runs the MCP server over the Streamable HTTP transport for remote hosting. It is
+a separate Echo server that exposes the MCP endpoint at `/mcp` plus a `/health`
+endpoint. Optional bearer authentication is configured via `--mcp-http-token` or
+the `CONTEXTD_MCP_HTTP_TOKEN` environment variable; when unset, the server runs
+unauthenticated (intended for localhost/testing) and logs a warning.
+
+This Streamable HTTP MCP transport is separate from the REST `--http-port` API
+described below.
+
+### HTTP Mode (standalone REST API)
 
 ```bash
 contextd --http-port 9090
 ```
 
-Runs HTTP server with endpoints:
+Runs the REST HTTP server with endpoints:
 - `GET /api/v1/status` - Health check
 - `POST /api/v1/threshold` - Trigger context threshold
 - `POST /api/v1/scrub` - Scrub secrets from text
+
+---
+
+## Agent-Swarm Notifications
+
+When multiple agents connect to a single contextd server over the Streamable
+HTTP transport (stateful sessions), an agent can `resources/subscribe` to a
+collection URI (for example `contextd://{project_id}/memories`). When any agent
+records a memory, remediation, or checkpoint, subscribers receive a
+`notifications/resources/updated` event and can re-read the shared knowledge,
+keeping a swarm in sync over one knowledge layer.
+
+See [Agent-Swarm Notifications spec](./spec/mcp-protocol/notifications-agent-swarm.md).
 
 ---
 

--- a/docs/plans/2026-06-19-mcp-protocol-expansion.md
+++ b/docs/plans/2026-06-19-mcp-protocol-expansion.md
@@ -1,0 +1,101 @@
+# MCP Protocol Expansion — Implementation Plan
+
+**Status**: In progress
+**Created**: 2026-06-19
+**Branch**: `claude/mcp-full-protocol-v8of4b`
+
+## Goal
+
+Expand contextd's MCP server from a Tools-only/stdio surface to the full MCP
+server surface — Resources, Prompts, and client primitives (logging,
+elicitation) — plus remote hosting over Streamable HTTP and an agent-swarm
+notification mechanism.
+
+Evaluated against: https://modelcontextprotocol.io/docs/learn/architecture
+
+## Decisions (locked 2026-06-19)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| Prompts | Richness | **Static instruction templates** mirroring the slash commands (no per-prompt service calls) |
+| Auth | Remote HTTP auth timing | **Bearer token now** — shared-token middleware on the Echo MCP server |
+| #6 | Swarm notifications depth | **Design doc + full impl** (subscribe + `ResourceUpdated` broadcast + tests) |
+| HTTP | REST/MCP consolidation | **Later** — keep separate Echo servers for now |
+
+## Completed
+
+- Streamable HTTP transport as a **separate Echo server** (`internal/mcp/streamable.go`):
+  `Server.StreamableHandler`, `Server.RunHTTP`. Stateful sessions (required for
+  swarm subscriptions). `--mcp-http-port` / `--mcp-http-host` flags.
+- serverInfo name `contextd-v2` → `contextd` (#5).
+
+## Phases
+
+### Phase 0 — Bearer-token auth (pull-forward of Phase E auth)
+- `StreamableHTTPConfig.Token`; Echo middleware on the `/mcp` route requiring
+  `Authorization: Bearer <token>` when a token is configured.
+- `/health` stays unauthenticated.
+- Token source: `--mcp-http-token` flag and/or `CONTEXTD_MCP_HTTP_TOKEN` env.
+- If no token is configured: serve open but log a prominent warning (intended
+  for localhost/testing only).
+- Tests: 401 without/with-wrong token, 200 with correct token, open+warn when unset.
+
+### Phase A — Resources (#1) · `internal/mcp/resources.go`
+- URI scheme: `contextd://{project_id}/<kind>[/{id}]`.
+- Collection templates: `…/memories`, `…/checkpoints`, `…/remediations`.
+- By-id templates: `…/memory/{id}`, `…/checkpoint/{id}`, `…/remediation/{id}`.
+- Static `contextd://help` documenting the scheme.
+- Handlers: parse URI → `withTenantContext` → service call
+  (`reasoningbank.GetByProjectID`/`ListMemories`, `checkpoint.Get`/`List`,
+  `remediation.GetByScope`/`Search`) → **scrub** text fields → JSON
+  `ReadResourceResult` (`mimeType: application/json`). `ResourceNotFoundError`
+  on miss. Tenant isolation via project_id in URI (fail-closed).
+- Tests: collection read, by-id read, not-found, scrubbing applied.
+
+### Phase B — Prompts (#2) · `internal/mcp/prompts.go`
+- Static prompts, one per feature: `contextd_checkpoint(summary?)`,
+  `contextd_remember(content?)`, `contextd_diagnose(error)`,
+  `contextd_resume(checkpoint_id?)`, `contextd_status`, `contextd_search(query)`.
+- Each returns a `GetPromptResult` whose user message contains the workflow
+  instructions (parity with the plugin slash commands), templating `{{args}}`.
+- Tests: `prompts/list` count, `prompts/get` messages, argument substitution.
+
+### Phase D — Agent-swarm notifications (#6)
+- Design doc: `docs/spec/mcp-protocol/notifications-agent-swarm.md`.
+- Mechanism: stateful HTTP sessions; agents `resources/subscribe` to a
+  collection URI (`contextd://{project}/memories|checkpoints|remediations`).
+  On record (`memory_record`, `remediation_record`, `checkpoint_save`) the
+  server calls `s.mcp.ResourceUpdated(ctx, {URI: collection})`, pushing
+  `notifications/resources/updated` to subscribed sessions; other agents
+  re-read and inherit shared knowledge.
+- Helper `s.notifyCollectionUpdated(ctx, projectID, kind)` invoked from the
+  record handlers. Tenant-scoped (only the matching project's collection URI).
+- Doc covers: topology, subscription model, fan-out, self-notify handling,
+  ordering, failure modes, security (tenant isolation), limits.
+- Tests: subscribe → record → assert `updated` delivered over in-memory transports.
+
+### Phase C — Logging + Elicitation (#4)
+- Logging: `req.Session.Log(...)` progress on `repository_index`,
+  `repository_search`, `memory_consolidate`; no-op-safe when session is nil.
+- Elicitation: `checkpoint_resume` with no id + multiple checkpoints →
+  `req.Session.Elicit` a choice; graceful fallback to returning the list when
+  the client lacks elicitation capability.
+- Tests: handlers unaffected when logging; elicitation fallback path.
+
+### Phase E — HTTP consolidation (later)
+- Move REST routes (`/scrub`, `/threshold`, `/status`) onto the Echo MCP
+  server; delete `internal/http`. (Auth already added in Phase 0.)
+
+## Cross-cutting
+
+- `registerResources()` and `registerPrompts()` wired into `NewServer` (served
+  over both stdio and HTTP via the shared `*mcp.Server`).
+- SDK auto-declares the `resources`, `prompts`, and `logging` capabilities when
+  `Add*` is called.
+- Docs: update `docs/CONTEXTD.md` (add Resources/Prompts tables), `README.md`,
+  `CHANGELOG.md`. Update in-repo plugin per Priority #3 (new prompts can ship as
+  plugin prompts). Consider `VERSION` bump on completion.
+
+## Sequencing
+
+Phase 0 → A → B → D → C → E. (#6 depends on the Phase A collection URIs.)

--- a/docs/spec/mcp-protocol/notifications-agent-swarm.md
+++ b/docs/spec/mcp-protocol/notifications-agent-swarm.md
@@ -1,0 +1,176 @@
+# Agent-Swarm Notifications
+
+**Status:** Design (Phase D of MCP Protocol Expansion)
+**Date:** 2026-06-19
+**Spec area:** MCP protocol — resource subscriptions / notifications
+
+## Problem
+
+contextd now supports a **Streamable HTTP transport with stateful sessions**, so
+multiple AI agents (each an MCP client) can connect to **one** contextd server
+at the same time. We call this an *agent swarm*: the agents share the same
+ReasoningBank memories, checkpoints, and remediations.
+
+Sharing storage is not enough. When one agent records a new memory (or a
+remediation, or a checkpoint), the other agents have no way to know fresh shared
+knowledge exists — they keep working from a stale view until they happen to
+search again. We want a **push**: when agent A records, agents B and C are told
+the relevant collection changed so they can re-read it.
+
+## Topology
+
+```
+        ┌─────────┐   ┌─────────┐   ┌─────────┐
+        │ Agent A │   │ Agent B │   │ Agent C │   (MCP clients)
+        └────┬────┘   └────┬────┘   └────┬────┘
+             │             │             │
+             └──── Streamable HTTP (stateful sessions) ────┐
+                           │                               │
+                    ┌──────▼───────────────────────────────▼─┐
+                    │            ONE contextd server          │
+                    │  shared memories / checkpoints / remed. │
+                    └─────────────────────────────────────────┘
+```
+
+- **HTTP transport (stateful):** many clients, many sessions, one server. This
+  is the only transport where swarm features apply.
+- **stdio transport:** exactly one client per server process, so there is no
+  swarm to coordinate — notifications are harmless no-ops there (no other
+  sessions to notify).
+
+## Mechanism
+
+The swarm is built on three standard MCP pieces:
+
+1. **Collection resources.** Each project exposes three collection URIs:
+   - `contextd://{project_id}/memories`
+   - `contextd://{project_id}/checkpoints`
+   - `contextd://{project_id}/remediations`
+2. **`resources/subscribe`.** An agent that cares about a collection subscribes
+   to its URI. The go-sdk tracks subscriptions **per server session**
+   automatically (`uri -> {session}` map inside the SDK `Server`).
+3. **`ResourceUpdated` broadcast.** When any agent records, the corresponding
+   record handler calls the helper:
+
+   ```go
+   func (s *Server) notifyCollectionUpdated(ctx context.Context, projectID, kind string)
+   ```
+
+   which builds `contextd://{project_id}/{kind}` and calls
+   `s.mcp.ResourceUpdated(ctx, &mcp.ResourceUpdatedNotificationParams{URI: uri})`.
+   The SDK fans `notifications/resources/updated` out to exactly the sessions
+   subscribed to that URI.
+
+Record-handler wiring (done by the integrator, not in `notifications.go`):
+
+| Tool                 | kind            |
+|----------------------|-----------------|
+| `memory_record`      | `memories`      |
+| `remediation_record` | `remediations`  |
+| `checkpoint_save`    | `checkpoints`   |
+
+### Sequence
+
+```mermaid
+sequenceDiagram
+    participant A as Agent A
+    participant B as Agent B
+    participant C as Agent C
+    participant S as contextd server
+
+    B->>S: resources/subscribe contextd://proj/memories
+    C->>S: resources/subscribe contextd://proj/memories
+    A->>S: memory_record (project=proj)
+    Note over S: record persists, then<br/>notifyCollectionUpdated(proj,"memories")
+    S->>S: ResourceUpdated{URI: contextd://proj/memories}
+    S--)B: notifications/resources/updated (memories)
+    S--)C: notifications/resources/updated (memories)
+    B->>S: resources/read contextd://proj/memories
+    C->>S: resources/read contextd://proj/memories
+    Note over B,C: B and C now share A's new knowledge
+```
+
+## Why `resources/updated`, not `tools/list_changed`
+
+The **data** behind a resource changed; the **set of tools** did not. The MCP
+semantics map cleanly:
+
+- `notifications/resources/updated` — "a resource you subscribed to changed; you
+  may want to re-read it." Exactly our case.
+- `notifications/tools/list_changed` — "the available tools changed." Irrelevant:
+  recording a memory does not add or remove tools.
+
+`resources/updated` is also **targeted** (only subscribers of that URI) and
+**opt-in** (clients that never subscribe are never bothered), whereas
+list-changed semantics are about the catalog, not the contents.
+
+## Tenant isolation
+
+The project_id is **embedded in the URI**. Subscriptions are keyed by URI, and
+`ResourceUpdated` only reaches sessions subscribed to *that* URI. Therefore:
+
+- `notifyCollectionUpdated(ctx, "tenant-A", "memories")` notifies only sessions
+  subscribed to `contextd://tenant-A/memories`.
+- An agent subscribed to `contextd://tenant-B/memories` receives **nothing** for
+  tenant-A activity.
+
+There is no cross-tenant leakage at the notification layer because the URI is
+the routing key, and a different project_id is a different URI. (Reading the
+resource itself remains fail-closed and tenant-scoped per the resources spec.)
+
+## Self-notification
+
+The agent that performed the record is *also* subscribed (typically) and will
+receive the same `resources/updated` it caused. This is **harmless and
+idempotent**:
+
+- A re-read of a collection is cheap and returns a consistent snapshot.
+- Clients may ignore updates they caused (e.g., correlate against a recent
+  record), but they are not required to — re-reading is always safe.
+
+We intentionally do **not** try to suppress self-notifications server-side: the
+server does not (and should not) attribute a record to a particular subscribing
+session, and the suppression logic would add state and edge cases for negligible
+benefit.
+
+## Failure modes
+
+| Mode | Behaviour |
+|------|-----------|
+| **No subscribers** | `ResourceUpdated` fans out to an empty set — a no-op. |
+| **Delivery best-effort** | `notifyCollectionUpdated` never returns an error to the record handler. A failed notification is logged (warn) and swallowed so it cannot fail the underlying record. |
+| **Disconnected session** | The SDK drops/cleans up sessions on close; a transient send failure to one session does not block others and does not affect the record. |
+| **nil server** | The helper guards `s == nil || s.mcp == nil` and returns immediately (no panic). Relevant for tests and partially-constructed servers. |
+| **Notification storms** | A burst of records produces a burst of updates. Subscribers re-read on each. See *Future work* (debouncing/coalescing). |
+
+## Limits & future work
+
+- **`list_changed` for collections.** If whole collections are added/removed
+  (new project, project deletion), `notifications/resources/list_changed` would
+  complement per-collection `updated`. Out of scope here.
+- **Debouncing / coalescing.** Under heavy write rates, coalesce multiple
+  updates for the same URI within a short window into one notification to avoid
+  storms and redundant re-reads.
+- **Per-item subscriptions.** Today subscription is per collection URI. A
+  finer-grained `contextd://{project}/memory/{id}` subscription could notify on
+  a single item, at the cost of more subscription bookkeeping.
+- **Ordering guarantees.** `resources/updated` carries no version/sequence; it
+  is a "something changed, re-read" hint. Agents must treat a re-read as the
+  source of truth rather than inferring ordering from notification arrival.
+- **Scaling many sessions.** Fan-out is O(subscribers per URI). For very large
+  swarms, consider batching, backpressure, or a pub/sub layer; the current
+  in-process map is appropriate for the expected swarm sizes.
+
+## Implementation reference
+
+- Helper: `internal/mcp/notifications.go` — `(*Server).notifyCollectionUpdated`.
+- Tests: `internal/mcp/notifications_test.go` — nil-safe / no-subscriber
+  no-ops and an end-to-end subscribe → record → `updated` delivery over
+  in-memory transports.
+- SDK API (go-sdk v1.1.0): `(*mcp.Server).ResourceUpdated`,
+  `mcp.ResourceUpdatedNotificationParams{URI}`,
+  `(*mcp.ClientSession).Subscribe`, `mcp.ClientOptions.ResourceUpdatedHandler`.
+  Note: the SDK only tracks subscriptions when the server is constructed with a
+  `SubscribeHandler`/`UnsubscribeHandler` pair (`mcp.ServerOptions`); the
+  production server must register these to enable the swarm mechanism.
+```

--- a/internal/mcp/clientcomm.go
+++ b/internal/mcp/clientcomm.go
@@ -1,0 +1,107 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/fyrsmithlabs/contextd/internal/checkpoint"
+)
+
+// clientLog sends a best-effort log message to the connected client over the
+// MCP logging channel. It is nil-safe (no-op if there is no session) and never
+// returns an error: client-facing logs must never break a tool call. The SDK
+// only forwards messages once the client has set a logging level, so this is
+// silently dropped when the client has not opted in.
+func (s *Server) clientLog(ctx context.Context, sess *mcp.ServerSession, level mcp.LoggingLevel, msg string) {
+	if sess == nil {
+		return
+	}
+	_ = sess.Log(ctx, &mcp.LoggingMessageParams{
+		Level:  level,
+		Logger: "contextd",
+		Data:   msg,
+	})
+}
+
+// chooseCheckpointViaElicit resolves which checkpoint to resume when the caller
+// did not supply a checkpoint_id.
+//
+// Return contract:
+//   - (id, "", nil)        → use this checkpoint id
+//   - ("", listMsg, nil)   → could not auto-resolve; caller should present
+//     listMsg so the user/agent can re-invoke with an explicit checkpoint_id
+//   - ("", "", err)        → hard error (nothing to resume / cannot list)
+//
+// When multiple checkpoints exist it asks the client to choose via MCP
+// elicitation; if the client does not support elicitation (or declines), it
+// falls back to returning a human-readable list.
+func (s *Server) chooseCheckpointViaElicit(ctx context.Context, sess *mcp.ServerSession, tenantID string) (string, string, error) {
+	cps, err := s.checkpointSvc.List(ctx, &checkpoint.ListRequest{TenantID: tenantID, Limit: 20})
+	if err != nil {
+		return "", "", fmt.Errorf("checkpoint_id is required and checkpoints could not be listed: %w", err)
+	}
+	if len(cps) == 0 {
+		return "", "", fmt.Errorf("no checkpoints found for tenant %q; nothing to resume", tenantID)
+	}
+	if len(cps) == 1 {
+		return cps[0].ID, "", nil
+	}
+
+	listMsg := s.formatCheckpointList(cps)
+
+	// No session → cannot elicit; return the list for manual selection.
+	if sess == nil {
+		return "", listMsg, nil
+	}
+
+	ids := make([]any, 0, len(cps))
+	for _, cp := range cps {
+		ids = append(ids, cp.ID)
+	}
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"checkpoint_id": map[string]any{
+				"type":        "string",
+				"enum":        ids,
+				"description": "ID of the checkpoint to resume",
+			},
+		},
+		"required": []string{"checkpoint_id"},
+	}
+
+	res, err := sess.Elicit(ctx, &mcp.ElicitParams{
+		Message:         "Multiple checkpoints exist. Choose one to resume:\n" + listMsg,
+		RequestedSchema: schema,
+	})
+	if err != nil {
+		// Client does not support elicitation — fall back to the list.
+		return "", listMsg, nil
+	}
+	if res.Action != "accept" || res.Content == nil {
+		return "", listMsg, nil
+	}
+	chosen, _ := res.Content["checkpoint_id"].(string)
+	if chosen == "" {
+		return "", listMsg, nil
+	}
+	return chosen, "", nil
+}
+
+// formatCheckpointList renders a compact, scrubbed list of checkpoints for the
+// user to choose from.
+func (s *Server) formatCheckpointList(cps []*checkpoint.Checkpoint) string {
+	var b strings.Builder
+	b.WriteString("Available checkpoints (re-run checkpoint_resume with one of these checkpoint_id values):\n")
+	for _, cp := range cps {
+		summary := s.scrubber.Scrub(cp.Summary).Scrubbed
+		if len(summary) > 80 {
+			summary = summary[:77] + "..."
+		}
+		fmt.Fprintf(&b, "- %s  (%s)  %s\n", cp.ID, cp.CreatedAt.Format("2006-01-02 15:04"), summary)
+	}
+	return b.String()
+}

--- a/internal/mcp/clientcomm_test.go
+++ b/internal/mcp/clientcomm_test.go
@@ -1,0 +1,93 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/fyrsmithlabs/contextd/internal/checkpoint"
+	"github.com/fyrsmithlabs/contextd/internal/secrets"
+)
+
+// fakeCheckpointSvc is a minimal checkpoint.Service for testing checkpoint
+// resolution. Only List is meaningful; the rest satisfy the interface.
+type fakeCheckpointSvc struct {
+	list    []*checkpoint.Checkpoint
+	listErr error
+}
+
+func (f *fakeCheckpointSvc) Save(context.Context, *checkpoint.SaveRequest) (*checkpoint.Checkpoint, error) {
+	return nil, nil
+}
+func (f *fakeCheckpointSvc) List(context.Context, *checkpoint.ListRequest) ([]*checkpoint.Checkpoint, error) {
+	return f.list, f.listErr
+}
+func (f *fakeCheckpointSvc) Resume(context.Context, *checkpoint.ResumeRequest) (*checkpoint.ResumeResponse, error) {
+	return nil, nil
+}
+func (f *fakeCheckpointSvc) Get(context.Context, string, string, string, string) (*checkpoint.Checkpoint, error) {
+	return nil, nil
+}
+func (f *fakeCheckpointSvc) Delete(context.Context, string, string, string, string) error {
+	return nil
+}
+func (f *fakeCheckpointSvc) Close() error { return nil }
+
+func newCheckpointTestServer(f *fakeCheckpointSvc) *Server {
+	return &Server{
+		checkpointSvc: f,
+		scrubber:      &secrets.NoopScrubber{},
+		logger:        zap.NewNop(),
+	}
+}
+
+func TestClientLog_NilSessionNoPanic(t *testing.T) {
+	s := newCheckpointTestServer(&fakeCheckpointSvc{})
+	// Must not panic with a nil session.
+	s.clientLog(context.Background(), nil, "info", "hello")
+}
+
+func TestChooseCheckpoint_NoneIsError(t *testing.T) {
+	s := newCheckpointTestServer(&fakeCheckpointSvc{list: nil})
+	id, msg, err := s.chooseCheckpointViaElicit(context.Background(), nil, "tenant")
+	if err == nil {
+		t.Fatalf("expected error for zero checkpoints, got id=%q msg=%q", id, msg)
+	}
+}
+
+func TestChooseCheckpoint_SingleAutoSelects(t *testing.T) {
+	s := newCheckpointTestServer(&fakeCheckpointSvc{list: []*checkpoint.Checkpoint{
+		{ID: "cp-1", Summary: "only one", CreatedAt: time.Now()},
+	}})
+	id, msg, err := s.chooseCheckpointViaElicit(context.Background(), nil, "tenant")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "cp-1" {
+		t.Errorf("id = %q, want cp-1", id)
+	}
+	if msg != "" {
+		t.Errorf("msg = %q, want empty", msg)
+	}
+}
+
+func TestChooseCheckpoint_MultipleNoSessionReturnsList(t *testing.T) {
+	s := newCheckpointTestServer(&fakeCheckpointSvc{list: []*checkpoint.Checkpoint{
+		{ID: "cp-1", Summary: "first", CreatedAt: time.Now()},
+		{ID: "cp-2", Summary: "second", CreatedAt: time.Now()},
+	}})
+	// nil session => cannot elicit => fall back to a list message.
+	id, msg, err := s.chooseCheckpointViaElicit(context.Background(), nil, "tenant")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "" {
+		t.Errorf("id = %q, want empty (manual selection)", id)
+	}
+	if !strings.Contains(msg, "cp-1") || !strings.Contains(msg, "cp-2") {
+		t.Errorf("list message missing checkpoint ids: %q", msg)
+	}
+}

--- a/internal/mcp/notifications.go
+++ b/internal/mcp/notifications.go
@@ -1,0 +1,66 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.uber.org/zap"
+)
+
+// notifyCollectionUpdated tells subscribed swarm members that a project's
+// resource collection changed (kind ∈ "memories","checkpoints","remediations").
+//
+// This powers the agent-swarm coordination mechanism: when several agents
+// (MCP clients) share a single contextd server over the Streamable HTTP
+// transport (stateful sessions), one agent recording shared knowledge should
+// prompt the others to re-read the affected collection. Agents express
+// interest by calling resources/subscribe on a collection URI; the go-sdk
+// tracks those subscriptions per server session, and ResourceUpdated fans the
+// notifications/resources/updated message out to exactly the sessions
+// subscribed to the matching URI.
+//
+// Callers (wired separately by the record handlers, not in this file):
+//   - memory_record      → notifyCollectionUpdated(ctx, projectID, "memories")
+//   - remediation_record → notifyCollectionUpdated(ctx, projectID, "remediations")
+//   - checkpoint_save     → notifyCollectionUpdated(ctx, projectID, "checkpoints")
+//
+// Tenant isolation: the URI embeds the project_id, so only agents subscribed
+// to that project's collection are notified — cross-tenant agents never see
+// another tenant's updates.
+//
+// Delivery is best-effort: notification failures are logged but never returned
+// to (or surfaced as an error for) the caller, because a failed re-read prompt
+// must not fail the underlying record operation. The function returns nothing
+// and never panics; a nil underlying MCP server is treated as a no-op.
+func (s *Server) notifyCollectionUpdated(ctx context.Context, projectID, kind string) {
+	if s == nil || s.mcp == nil {
+		return
+	}
+
+	// NOTE: build the URI inline. A collectionResourceURI helper is defined in
+	// another file in this package; duplicating it here would fail to compile.
+	uri := fmt.Sprintf("contextd://%s/%s", projectID, kind)
+
+	if err := s.mcp.ResourceUpdated(ctx, &mcp.ResourceUpdatedNotificationParams{URI: uri}); err != nil {
+		// Best-effort: log and move on. The record already succeeded; failing
+		// to notify subscribers should not propagate to the caller.
+		if s.logger != nil {
+			s.logger.Warn("failed to notify swarm of collection update",
+				zap.String("uri", uri),
+				zap.String("project_id", projectID),
+				zap.String("kind", kind),
+				zap.Error(err),
+			)
+		}
+		return
+	}
+
+	if s.logger != nil {
+		s.logger.Debug("notified swarm of collection update",
+			zap.String("uri", uri),
+			zap.String("project_id", projectID),
+			zap.String("kind", kind),
+		)
+	}
+}

--- a/internal/mcp/notifications_test.go
+++ b/internal/mcp/notifications_test.go
@@ -1,0 +1,132 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.uber.org/zap"
+)
+
+// newResourceHandler returns a trivial resource handler that echoes the
+// requested URI back as an empty JSON array. It satisfies the SDK's
+// requirement that a resource exist before a subscription is meaningful.
+func newResourceHandler() mcp.ResourceHandler {
+	return func(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		return &mcp.ReadResourceResult{
+			Contents: []*mcp.ResourceContents{{URI: req.Params.URI, Text: "[]"}},
+		}, nil
+	}
+}
+
+// TestNotifyCollectionUpdated_NoSubscribers asserts the helper is a safe no-op
+// (no error, no panic) when no client has subscribed. ResourceUpdated simply
+// fans out to an empty set of sessions.
+//
+// This uses the bare-server construction form: a *mcp.Server created with nil
+// options has no SubscribeHandler, so it cannot actually track subscriptions —
+// but ResourceUpdated is still callable and must not panic.
+func TestNotifyCollectionUpdated_NoSubscribers(t *testing.T) {
+	s := &Server{
+		mcp: mcp.NewServer(&mcp.Implementation{
+			Name:    "contextd",
+			Version: "test",
+		}, nil),
+		logger: zap.NewNop(),
+	}
+	s.mcp.AddResource(&mcp.Resource{URI: "contextd://proj/memories", Name: "m"}, newResourceHandler())
+
+	// Must not panic and must return cleanly even with zero subscribers.
+	s.notifyCollectionUpdated(context.Background(), "proj", "memories")
+	s.notifyCollectionUpdated(context.Background(), "proj", "remediations")
+	s.notifyCollectionUpdated(context.Background(), "proj", "checkpoints")
+}
+
+// TestNotifyCollectionUpdated_NilSafe asserts the helper guards against a nil
+// underlying MCP server (and a nil receiver) without panicking.
+func TestNotifyCollectionUpdated_NilSafe(t *testing.T) {
+	// nil mcp server
+	s := &Server{logger: zap.NewNop()}
+	s.notifyCollectionUpdated(context.Background(), "proj", "memories")
+
+	// nil receiver
+	var ns *Server
+	ns.notifyCollectionUpdated(context.Background(), "proj", "memories")
+}
+
+// TestNotifyCollectionUpdated_DeliversToSubscriber is the end-to-end swarm test:
+// a client subscribes to a collection URI, the server records (via
+// notifyCollectionUpdated), and the client must receive a
+// notifications/resources/updated for that exact URI.
+//
+// NOTE on construction: the SDK only tracks subscriptions when the server was
+// created with a SubscribeHandler/UnsubscribeHandler pair (see
+// (*Server).subscribe in the go-sdk, which returns ErrMethodNotFound when
+// SubscribeHandler is nil and never records the subscription). The production
+// contextd server therefore must register these handlers to support the swarm
+// mechanism. We mirror that here so the subscribe → notify → receive path is
+// exercised for real. The notifyCollectionUpdated helper under test is
+// agnostic to how the server was constructed.
+func TestNotifyCollectionUpdated_DeliversToSubscriber(t *testing.T) {
+	const uri = "contextd://proj/memories"
+
+	mcpServer := mcp.NewServer(&mcp.Implementation{
+		Name:    "contextd",
+		Version: "test",
+	}, &mcp.ServerOptions{
+		SubscribeHandler:   func(_ context.Context, _ *mcp.SubscribeRequest) error { return nil },
+		UnsubscribeHandler: func(_ context.Context, _ *mcp.UnsubscribeRequest) error { return nil },
+	})
+	mcpServer.AddResource(&mcp.Resource{URI: uri, Name: "m"}, newResourceHandler())
+
+	s := &Server{mcp: mcpServer, logger: zap.NewNop()}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Wire an in-memory transport pair: one end for the server session, one
+	// for the client session.
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+
+	serverSession, err := s.mcp.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	defer serverSession.Close()
+
+	// Client installs a handler for resources/updated notifications.
+	updated := make(chan string, 1)
+	client := mcp.NewClient(&mcp.Implementation{Name: "agent", Version: "test"}, &mcp.ClientOptions{
+		ResourceUpdatedHandler: func(_ context.Context, req *mcp.ResourceUpdatedNotificationRequest) {
+			// Non-blocking send; buffer of 1 is enough for this single event.
+			select {
+			case updated <- req.Params.URI:
+			default:
+			}
+		},
+	})
+
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer clientSession.Close()
+
+	// Agent subscribes to the collection it cares about.
+	if err := clientSession.Subscribe(ctx, &mcp.SubscribeParams{URI: uri}); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	// Another agent records shared knowledge → server broadcasts the update.
+	s.notifyCollectionUpdated(ctx, "proj", "memories")
+
+	select {
+	case got := <-updated:
+		if got != uri {
+			t.Fatalf("got updated notification for %q, want %q", got, uri)
+		}
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for resources/updated notification: %v", ctx.Err())
+	}
+}

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -1,0 +1,195 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// registerPrompts registers the static contextd MCP prompts. Each prompt
+// returns an instruction template (no service calls) that directs the agent to
+// invoke the appropriate contextd MCP tools. The prompts mirror the bundled
+// slash commands under plugins/contextd/commands/.
+func (s *Server) registerPrompts() {
+	s.mcp.AddPrompt(&mcp.Prompt{
+		Name:        "contextd_checkpoint",
+		Title:       "Save a resumable context checkpoint",
+		Description: "Save a resumable context checkpoint of this session via checkpoint_save.",
+		Arguments: []*mcp.PromptArgument{
+			{Name: "summary", Description: "Optional summary text to use for the checkpoint.", Required: false},
+		},
+	}, s.handleCheckpointPrompt)
+
+	s.mcp.AddPrompt(&mcp.Prompt{
+		Name:        "contextd_remember",
+		Title:       "Record a learning into contextd memory",
+		Description: "Record a durable learning from this session into the contextd ReasoningBank via memory_record.",
+		Arguments: []*mcp.PromptArgument{
+			{Name: "content", Description: "Optional explicit content to remember.", Required: false},
+		},
+	}, s.handleRememberPrompt)
+
+	s.mcp.AddPrompt(&mcp.Prompt{
+		Name:        "contextd_diagnose",
+		Title:       "Diagnose an error and find a known fix",
+		Description: "Diagnose an error via troubleshoot_diagnose and search for a known fix via remediation_search.",
+		Arguments: []*mcp.PromptArgument{
+			{Name: "error", Description: "The error message or description to diagnose.", Required: true},
+		},
+	}, s.handleDiagnosePrompt)
+
+	s.mcp.AddPrompt(&mcp.Prompt{
+		Name:        "contextd_resume",
+		Title:       "Resume from a contextd checkpoint",
+		Description: "List contextd checkpoints and resume from one via checkpoint_resume.",
+		Arguments: []*mcp.PromptArgument{
+			{Name: "checkpoint_id", Description: "Optional checkpoint id to resume directly.", Required: false},
+		},
+	}, s.handleResumePrompt)
+
+	s.mcp.AddPrompt(&mcp.Prompt{
+		Name:        "contextd_status",
+		Title:       "Show contextd memories, checkpoints, and project context",
+		Description: "Report the current contextd state for this session.",
+	}, s.handleStatusPrompt)
+
+	s.mcp.AddPrompt(&mcp.Prompt{
+		Name:        "contextd_search",
+		Title:       "Search contextd memories, remediations, and code",
+		Description: "Search contextd memories, remediations, and code for a query.",
+		Arguments: []*mcp.PromptArgument{
+			{Name: "query", Description: "The search query.", Required: true},
+		},
+	}, s.handleSearchPrompt)
+}
+
+// promptMessage builds a single user-role prompt message wrapping text.
+func promptMessage(text string) *mcp.PromptMessage {
+	return &mcp.PromptMessage{
+		Role:    "user",
+		Content: &mcp.TextContent{Text: text},
+	}
+}
+
+func promptArg(args map[string]string, key string) string {
+	if args == nil {
+		return ""
+	}
+	return args[key]
+}
+
+func (s *Server) handleCheckpointPrompt(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	summary := promptArg(req.Params.Arguments, "summary")
+
+	text := "Save a resumable checkpoint of this session using the contextd `checkpoint_save` MCP tool.\n\n"
+	if summary != "" {
+		text += fmt.Sprintf("Use this summary text for the checkpoint: %q\n\n", summary)
+	} else {
+		text += "Build a resumable summary from the recent conversation covering:\n" +
+			"- What was done: the concrete state reached so far.\n" +
+			"- What's next: the immediate next step(s).\n" +
+			"- Open questions / blockers: anything unresolved.\n\n"
+	}
+	text += "Then call `checkpoint_save` with that summary and report the returned checkpoint id with a one-line confirmation of what was saved."
+
+	return &mcp.GetPromptResult{
+		Description: "Save a resumable context checkpoint via checkpoint_save.",
+		Messages:    []*mcp.PromptMessage{promptMessage(text)},
+	}, nil
+}
+
+func (s *Server) handleRememberPrompt(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	content := promptArg(req.Params.Arguments, "content")
+
+	text := "Record a durable learning into the contextd ReasoningBank using the `memory_record` MCP tool.\n\n"
+	if content != "" {
+		text += fmt.Sprintf("Record this content: %q\n\n", content)
+	} else {
+		text += "Distill the key insight from the recent conversation.\n\n"
+	}
+	text += "Capture the WHY, not just the what: the approach that worked, rejected alternatives, the deciding tradeoff, and any consequences or gotchas. " +
+		"Call `memory_record` with the distilled content and confirm what was stored in one or two lines. " +
+		"Never record secrets or credentials, and skip recording insights that are already obvious from the code or docs."
+
+	return &mcp.GetPromptResult{
+		Description: "Record a learning into contextd memory via memory_record.",
+		Messages:    []*mcp.PromptMessage{promptMessage(text)},
+	}, nil
+}
+
+func (s *Server) handleDiagnosePrompt(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	errMsg := promptArg(req.Params.Arguments, "error")
+
+	text := "Diagnose an error using contextd.\n\n"
+	if errMsg != "" {
+		text += fmt.Sprintf("The error to diagnose is: %q\n\n", errMsg)
+	} else {
+		text += "Use the most recent error in the conversation.\n\n"
+	}
+	text += "Steps:\n" +
+		"1. Call `troubleshoot_diagnose` with the error to get the likely cause (category + analysis).\n" +
+		"2. Call `remediation_search` with the stable part of the error signature to find any fix that worked before.\n" +
+		"3. Present the diagnosis, any matching known remediation clearly marked as a prior fix, and a recommended next step.\n" +
+		"4. After the user applies a fix and confirms it works, offer to record it with `remediation_record` so the fix is reused next time."
+
+	return &mcp.GetPromptResult{
+		Description: "Diagnose an error via troubleshoot_diagnose and remediation_search.",
+		Messages:    []*mcp.PromptMessage{promptMessage(text)},
+	}, nil
+}
+
+func (s *Server) handleResumePrompt(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	checkpointID := promptArg(req.Params.Arguments, "checkpoint_id")
+
+	text := "Resume work from a previously saved contextd checkpoint.\n\n"
+	if checkpointID != "" {
+		text += fmt.Sprintf("Call `checkpoint_resume` with checkpoint id %q.\n\n", checkpointID)
+	} else {
+		text += "Call `checkpoint_list` and show the available checkpoints (id, summary, timestamp), then ask the user which one to resume before calling `checkpoint_resume` with the chosen id.\n\n"
+	}
+	text += "Default to the `context` resume level unless the user asks for `summary` (quick reorientation) or `full` (deep resumption after a long gap). " +
+		"Summarize the restored state and state the immediate next step so work can continue."
+
+	return &mcp.GetPromptResult{
+		Description: "Resume from a contextd checkpoint via checkpoint_resume.",
+		Messages:    []*mcp.PromptMessage{promptMessage(text)},
+	}, nil
+}
+
+func (s *Server) handleStatusPrompt(_ context.Context, _ *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	text := "Report the current contextd state for this session.\n\n" +
+		"Steps:\n" +
+		"1. Call `checkpoint_list` to get available checkpoints (count + most recent).\n" +
+		"2. Run a broad `memory_search` for the current project to gauge how many relevant memories exist.\n" +
+		"3. Summarize in a compact status block:\n" +
+		"   - The tenant / project context contextd is operating under (auto-derived from the repository).\n" +
+		"   - The number of checkpoints and the most recent one.\n" +
+		"   - Whether relevant memories exist for this project.\n" +
+		"If the contextd MCP server is unavailable, say so and suggest checking that `contextd --mcp` is running."
+
+	return &mcp.GetPromptResult{
+		Description: "Show contextd memories, checkpoints, and project context.",
+		Messages:    []*mcp.PromptMessage{promptMessage(text)},
+	}, nil
+}
+
+func (s *Server) handleSearchPrompt(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	query := promptArg(req.Params.Arguments, "query")
+
+	text := "Search contextd for anything relevant to the query.\n\n"
+	if query != "" {
+		text += fmt.Sprintf("The query is: %q\n\n", query)
+	}
+	text += "Run these searches for the query:\n" +
+		"- `memory_search` — past strategies and decisions.\n" +
+		"- `remediation_search` — known error fixes.\n" +
+		"- `semantic_search` (with `project_path: \".\"`) — relevant code in this repository.\n\n" +
+		"Merge and present the most relevant hits, grouped by source (Memories / Remediations / Code), each with a one-line relevance note. " +
+		"If nothing relevant is found, say so plainly rather than padding with weak matches."
+
+	return &mcp.GetPromptResult{
+		Description: "Search contextd memories, remediations, and code.",
+		Messages:    []*mcp.PromptMessage{promptMessage(text)},
+	}, nil
+}

--- a/internal/mcp/prompts_test.go
+++ b/internal/mcp/prompts_test.go
@@ -1,0 +1,104 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.uber.org/zap"
+)
+
+func newPromptTestServer(t *testing.T) *Server {
+	t.Helper()
+	s := &Server{
+		mcp:    mcp.NewServer(&mcp.Implementation{Name: "contextd", Version: "test"}, nil),
+		logger: zap.NewNop(),
+	}
+	s.registerPrompts()
+	return s
+}
+
+func connectPromptSession(t *testing.T, s *Server) *mcp.ClientSession {
+	t.Helper()
+	ctx := context.Background()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+
+	serverSession, err := s.mcp.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "test"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = clientSession.Close() })
+
+	return clientSession
+}
+
+func TestRegisterPromptsListsAllSix(t *testing.T) {
+	s := newPromptTestServer(t)
+	session := connectPromptSession(t, s)
+	ctx := context.Background()
+
+	res, err := session.ListPrompts(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListPrompts: %v", err)
+	}
+
+	got := make(map[string]bool, len(res.Prompts))
+	for _, p := range res.Prompts {
+		got[p.Name] = true
+	}
+
+	want := []string{
+		"contextd_checkpoint",
+		"contextd_remember",
+		"contextd_diagnose",
+		"contextd_resume",
+		"contextd_status",
+		"contextd_search",
+	}
+	for _, name := range want {
+		if !got[name] {
+			t.Errorf("expected prompt %q to be registered, got %v", name, got)
+		}
+	}
+}
+
+func TestGetSearchPromptWeavesArgument(t *testing.T) {
+	s := newPromptTestServer(t)
+	session := connectPromptSession(t, s)
+	ctx := context.Background()
+
+	res, err := session.GetPrompt(ctx, &mcp.GetPromptParams{
+		Name:      "contextd_search",
+		Arguments: map[string]string{"query": "auth bug"},
+	})
+	if err != nil {
+		t.Fatalf("GetPrompt: %v", err)
+	}
+	if len(res.Messages) == 0 {
+		t.Fatal("expected at least one prompt message")
+	}
+
+	tc, ok := res.Messages[0].Content.(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected *mcp.TextContent, got %T", res.Messages[0].Content)
+	}
+	text := tc.Text
+
+	if !strings.Contains(text, "auth bug") {
+		t.Errorf("expected message text to contain query %q, got: %s", "auth bug", text)
+	}
+	for _, tool := range []string{"memory_search", "remediation_search", "semantic_search"} {
+		if !strings.Contains(text, tool) {
+			t.Errorf("expected message text to mention tool %q, got: %s", tool, text)
+		}
+	}
+}

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -1,0 +1,389 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/fyrsmithlabs/contextd/internal/checkpoint"
+	"github.com/fyrsmithlabs/contextd/internal/reasoningbank"
+	"github.com/fyrsmithlabs/contextd/internal/remediation"
+	"github.com/fyrsmithlabs/contextd/internal/sanitize"
+)
+
+// resourceScheme is the URI scheme used for all contextd resources.
+const resourceScheme = "contextd"
+
+// Resource collection kinds used in URIs.
+const (
+	kindMemories     = "memories"
+	kindMemory       = "memory"
+	kindCheckpoints  = "checkpoints"
+	kindCheckpoint   = "checkpoint"
+	kindRemediation  = "remediation"
+	kindRemediations = "remediations"
+)
+
+// collectionResourceURI builds a collection-level resource URI of the form
+// "contextd://<projectID>/<kind>". It is reused by other files in this package.
+func collectionResourceURI(projectID, kind string) string {
+	return fmt.Sprintf("%s://%s/%s", resourceScheme, projectID, kind)
+}
+
+// itemResourceURI builds an item-level resource URI of the form
+// "contextd://<projectID>/<kind>/<id>". It is reused by other files in this package.
+func itemResourceURI(projectID, kind, id string) string {
+	return fmt.Sprintf("%s://%s/%s/%s", resourceScheme, projectID, kind, id)
+}
+
+// parsedResourceURI holds the components extracted from a contextd resource URI.
+type parsedResourceURI struct {
+	projectID string
+	kind      string
+	id        string
+	query     string
+}
+
+// parseResourceURI parses a "contextd://<project_id>/<kind>[/<id>][?query]" URI.
+// It returns the parsed components or an error if the URI is malformed. The
+// project_id is NOT validated here; callers must validate it with
+// sanitize.ValidateProjectID and fail closed on error.
+func parseResourceURI(raw string) (parsedResourceURI, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return parsedResourceURI{}, fmt.Errorf("invalid uri: %w", err)
+	}
+	if u.Scheme != resourceScheme {
+		return parsedResourceURI{}, fmt.Errorf("unexpected scheme %q", u.Scheme)
+	}
+
+	// For "contextd://<project_id>/<kind>", the project_id lands in u.Host
+	// and the remainder ("/<kind>[/<id>]") lands in u.Path.
+	projectID := u.Host
+	if projectID == "" {
+		return parsedResourceURI{}, fmt.Errorf("missing project_id in uri")
+	}
+
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	// strings.Split on "" yields [""], normalize to empty.
+	if len(parts) == 1 && parts[0] == "" {
+		parts = nil
+	}
+	if len(parts) == 0 {
+		return parsedResourceURI{}, fmt.Errorf("missing resource kind in uri")
+	}
+
+	p := parsedResourceURI{
+		projectID: projectID,
+		kind:      parts[0],
+		query:     u.Query().Get("query"),
+	}
+	if len(parts) >= 2 {
+		p.id = parts[1]
+	}
+	return p, nil
+}
+
+// registerResources registers MCP resources and resource templates that expose
+// memories, checkpoints, and remediations as readable resources.
+func (s *Server) registerResources() {
+	// Static help resource documenting the URI scheme.
+	s.mcp.AddResource(&mcp.Resource{
+		Name:        "contextd-help",
+		URI:         resourceScheme + "://help",
+		Title:       "contextd Resource Help",
+		Description: "Documentation of the contextd:// resource URI scheme",
+		MIMEType:    "application/json",
+	}, s.handleHelpResource)
+
+	// Recent memories for a project.
+	s.mcp.AddResourceTemplate(&mcp.ResourceTemplate{
+		Name:        "contextd-memories",
+		URITemplate: resourceScheme + "://{project_id}/memories",
+		Title:       "Project Memories",
+		Description: "Recent memories (learnings/strategies) for a project",
+		MIMEType:    "application/json",
+	}, s.handleResource)
+
+	// Single memory by ID.
+	s.mcp.AddResourceTemplate(&mcp.ResourceTemplate{
+		Name:        "contextd-memory",
+		URITemplate: resourceScheme + "://{project_id}/memory/{id}",
+		Title:       "Project Memory",
+		Description: "A single memory by ID for a project",
+		MIMEType:    "application/json",
+	}, s.handleResource)
+
+	// Checkpoint list for a project.
+	s.mcp.AddResourceTemplate(&mcp.ResourceTemplate{
+		Name:        "contextd-checkpoints",
+		URITemplate: resourceScheme + "://{project_id}/checkpoints",
+		Title:       "Project Checkpoints",
+		Description: "Saved context checkpoints for a project",
+		MIMEType:    "application/json",
+	}, s.handleResource)
+
+	// Single checkpoint by ID.
+	s.mcp.AddResourceTemplate(&mcp.ResourceTemplate{
+		Name:        "contextd-checkpoint",
+		URITemplate: resourceScheme + "://{project_id}/checkpoint/{id}",
+		Title:       "Project Checkpoint",
+		Description: "A single checkpoint by ID for a project",
+		MIMEType:    "application/json",
+	}, s.handleResource)
+
+	// Single remediation by ID.
+	s.mcp.AddResourceTemplate(&mcp.ResourceTemplate{
+		Name:        "contextd-remediation",
+		URITemplate: resourceScheme + "://{project_id}/remediation/{id}",
+		Title:       "Project Remediation",
+		Description: "A single remediation (error fix) by ID for a project",
+		MIMEType:    "application/json",
+	}, s.handleResource)
+
+	// Remediation search for a project.
+	s.mcp.AddResourceTemplate(&mcp.ResourceTemplate{
+		Name:        "contextd-remediations",
+		URITemplate: resourceScheme + "://{project_id}/remediations{?query}",
+		Title:       "Project Remediations",
+		Description: "Search remediations (error fixes) for a project via ?query=",
+		MIMEType:    "application/json",
+	}, s.handleResource)
+}
+
+// jsonResource marshals v to JSON and wraps it in a ReadResourceResult for uri.
+func jsonResource(uri string, v interface{}) (*mcp.ReadResourceResult, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("marshal resource: %w", err)
+	}
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{
+			{
+				URI:      uri,
+				MIMEType: "application/json",
+				Text:     string(data),
+			},
+		},
+	}, nil
+}
+
+// handleHelpResource returns a JSON object documenting the URI scheme.
+func (s *Server) handleHelpResource(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	uri := req.Params.URI
+	help := map[string]interface{}{
+		"scheme":      resourceScheme,
+		"description": "contextd exposes memories, checkpoints, and remediations as MCP resources. Replace {project_id} with your project identifier.",
+		"resources": []map[string]string{
+			{"uri": resourceScheme + "://help", "description": "This help document."},
+			{"uri": resourceScheme + "://{project_id}/memories", "description": "Recent memories for a project (up to 20)."},
+			{"uri": resourceScheme + "://{project_id}/memory/{id}", "description": "A single memory by ID."},
+			{"uri": resourceScheme + "://{project_id}/checkpoints", "description": "Checkpoints for a project."},
+			{"uri": resourceScheme + "://{project_id}/checkpoint/{id}", "description": "A single checkpoint by ID."},
+			{"uri": resourceScheme + "://{project_id}/remediation/{id}", "description": "A single remediation by ID."},
+			{"uri": resourceScheme + "://{project_id}/remediations{?query}", "description": "Search remediations; provide ?query=<text>."},
+		},
+	}
+	return jsonResource(uri, help)
+}
+
+// handleResource dispatches a templated resource read based on the parsed URI.
+// It validates the project_id (fail-closed) and routes to the appropriate
+// service-backed handler.
+func (s *Server) handleResource(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	uri := req.Params.URI
+
+	parsed, err := parseResourceURI(uri)
+	if err != nil {
+		return nil, mcp.ResourceNotFoundError(uri)
+	}
+
+	// Validate project_id (fail-closed): invalid project -> not found.
+	if err := sanitize.ValidateProjectID(parsed.projectID); err != nil {
+		return nil, mcp.ResourceNotFoundError(uri)
+	}
+
+	// Establish tenant context: tenantID = projectID, teamID = "", projectID = projectID.
+	ctx, err = withTenantContext(ctx, parsed.projectID, "", parsed.projectID)
+	if err != nil {
+		return nil, mcp.ResourceNotFoundError(uri)
+	}
+
+	switch parsed.kind {
+	case kindMemories:
+		return s.readMemories(ctx, uri, parsed.projectID)
+	case kindMemory:
+		if parsed.id == "" {
+			return nil, mcp.ResourceNotFoundError(uri)
+		}
+		return s.readMemory(ctx, uri, parsed.projectID, parsed.id)
+	case kindCheckpoints:
+		return s.readCheckpoints(ctx, uri, parsed.projectID)
+	case kindCheckpoint:
+		if parsed.id == "" {
+			return nil, mcp.ResourceNotFoundError(uri)
+		}
+		return s.readCheckpoint(ctx, uri, parsed.projectID, parsed.id)
+	case kindRemediation:
+		if parsed.id == "" {
+			return nil, mcp.ResourceNotFoundError(uri)
+		}
+		return s.readRemediation(ctx, uri, parsed.projectID, parsed.id)
+	case kindRemediations:
+		return s.readRemediations(ctx, uri, parsed.projectID, parsed.query)
+	default:
+		return nil, mcp.ResourceNotFoundError(uri)
+	}
+}
+
+// readMemories returns recent memories for a project (limit 20, offset 0).
+func (s *Server) readMemories(ctx context.Context, uri, projectID string) (*mcp.ReadResourceResult, error) {
+	memories, err := s.reasoningbankSvc.ListMemories(ctx, projectID, 20, 0)
+	if err != nil {
+		return nil, mcp.ResourceNotFoundError(uri)
+	}
+
+	out := make([]map[string]interface{}, 0, len(memories))
+	for i := range memories {
+		out = append(out, s.memoryToMap(&memories[i]))
+	}
+	return jsonResource(uri, map[string]interface{}{
+		"project_id": projectID,
+		"count":      len(out),
+		"memories":   out,
+	})
+}
+
+// readMemory returns a single memory by ID.
+func (s *Server) readMemory(ctx context.Context, uri, projectID, id string) (*mcp.ReadResourceResult, error) {
+	mem, err := s.reasoningbankSvc.GetByProjectID(ctx, projectID, id)
+	if err != nil || mem == nil {
+		return nil, mcp.ResourceNotFoundError(uri)
+	}
+	return jsonResource(uri, s.memoryToMap(mem))
+}
+
+// readCheckpoints returns the checkpoint list for a project.
+func (s *Server) readCheckpoints(ctx context.Context, uri, projectID string) (*mcp.ReadResourceResult, error) {
+	checkpoints, err := s.checkpointSvc.List(ctx, &checkpoint.ListRequest{
+		TenantID:    projectID,
+		ProjectID:   projectID,
+		ProjectPath: projectID,
+		Limit:       20,
+	})
+	if err != nil {
+		return nil, mcp.ResourceNotFoundError(uri)
+	}
+
+	out := make([]map[string]interface{}, 0, len(checkpoints))
+	for _, cp := range checkpoints {
+		out = append(out, s.checkpointToMap(cp))
+	}
+	return jsonResource(uri, map[string]interface{}{
+		"project_id":  projectID,
+		"count":       len(out),
+		"checkpoints": out,
+	})
+}
+
+// readCheckpoint returns a single checkpoint by ID.
+func (s *Server) readCheckpoint(ctx context.Context, uri, projectID, id string) (*mcp.ReadResourceResult, error) {
+	cp, err := s.checkpointSvc.Get(ctx, projectID, "", projectID, id)
+	if err != nil || cp == nil {
+		return nil, mcp.ResourceNotFoundError(uri)
+	}
+	return jsonResource(uri, s.checkpointToMap(cp))
+}
+
+// readRemediation returns a single remediation by ID (project scope).
+func (s *Server) readRemediation(ctx context.Context, uri, projectID, id string) (*mcp.ReadResourceResult, error) {
+	rem, err := s.remediationSvc.Get(ctx, projectID, id)
+	if err != nil || rem == nil {
+		return nil, mcp.ResourceNotFoundError(uri)
+	}
+	return jsonResource(uri, s.remediationToMap(rem))
+}
+
+// readRemediations searches remediations for a project. If query is empty, it
+// returns an empty contents list with an explanatory JSON note rather than
+// calling Search with an empty query.
+func (s *Server) readRemediations(ctx context.Context, uri, projectID, query string) (*mcp.ReadResourceResult, error) {
+	if strings.TrimSpace(query) == "" {
+		return jsonResource(uri, map[string]interface{}{
+			"project_id":   projectID,
+			"count":        0,
+			"note":         "provide a non-empty ?query= parameter to search remediations",
+			"remediations": []interface{}{},
+		})
+	}
+
+	results, err := s.remediationSvc.Search(ctx, &remediation.SearchRequest{
+		Query:       query,
+		TenantID:    projectID,
+		Scope:       remediation.ScopeProject,
+		ProjectPath: projectID,
+		Limit:       20,
+	})
+	if err != nil {
+		return nil, mcp.ResourceNotFoundError(uri)
+	}
+
+	out := make([]map[string]interface{}, 0, len(results))
+	for _, sr := range results {
+		m := s.remediationToMap(&sr.Remediation)
+		m["score"] = sr.Score
+		out = append(out, m)
+	}
+	return jsonResource(uri, map[string]interface{}{
+		"project_id":   projectID,
+		"query":        query,
+		"count":        len(out),
+		"remediations": out,
+	})
+}
+
+// memoryToMap converts a memory to a JSON-serializable map with scrubbed free text.
+func (s *Server) memoryToMap(m *reasoningbank.Memory) map[string]interface{} {
+	return map[string]interface{}{
+		"id":          m.ID,
+		"title":       m.Title,
+		"description": s.scrubber.Scrub(m.Description).Scrubbed,
+		"content":     s.scrubber.Scrub(m.Content).Scrubbed,
+		"outcome":     string(m.Outcome),
+		"confidence":  m.Confidence,
+		"tags":        m.Tags,
+		"created_at":  m.CreatedAt,
+	}
+}
+
+// checkpointToMap converts a checkpoint to a JSON-serializable map with scrubbed free text.
+func (s *Server) checkpointToMap(cp *checkpoint.Checkpoint) map[string]interface{} {
+	return map[string]interface{}{
+		"id":          cp.ID,
+		"session_id":  cp.SessionID,
+		"name":        cp.Name,
+		"description": s.scrubber.Scrub(cp.Description).Scrubbed,
+		"summary":     s.scrubber.Scrub(cp.Summary).Scrubbed,
+		"context":     s.scrubber.Scrub(cp.Context).Scrubbed,
+		"token_count": cp.TokenCount,
+		"created_at":  cp.CreatedAt,
+	}
+}
+
+// remediationToMap converts a remediation to a JSON-serializable map with scrubbed free text.
+func (s *Server) remediationToMap(r *remediation.Remediation) map[string]interface{} {
+	return map[string]interface{}{
+		"id":         r.ID,
+		"title":      r.Title,
+		"problem":    s.scrubber.Scrub(r.Problem).Scrubbed,
+		"root_cause": s.scrubber.Scrub(r.RootCause).Scrubbed,
+		"solution":   s.scrubber.Scrub(r.Solution).Scrubbed,
+		"category":   string(r.Category),
+		"confidence": r.Confidence,
+		"tags":       r.Tags,
+	}
+}

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -1,0 +1,185 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.uber.org/zap"
+
+	"github.com/fyrsmithlabs/contextd/internal/secrets"
+)
+
+func newResourceTestServer(t *testing.T) *Server {
+	t.Helper()
+	s := &Server{
+		mcp:      mcp.NewServer(&mcp.Implementation{Name: "contextd", Version: "test"}, nil),
+		scrubber: &secrets.NoopScrubber{},
+		logger:   zap.NewNop(),
+		// Services intentionally left nil: passing tests exercise registration,
+		// help, and template listing only — they never invoke a backing service.
+	}
+	s.registerResources()
+	return s
+}
+
+func connectResourceSession(t *testing.T, s *Server) *mcp.ClientSession {
+	t.Helper()
+	ctx := context.Background()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+
+	serverSession, err := s.mcp.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "test"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = clientSession.Close() })
+
+	return clientSession
+}
+
+func TestRegisterResourcesDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("registerResources panicked: %v", r)
+		}
+	}()
+	_ = newResourceTestServer(t)
+}
+
+func TestRegisterResourcesListsHelp(t *testing.T) {
+	s := newResourceTestServer(t)
+	session := connectResourceSession(t, s)
+	ctx := context.Background()
+
+	res, err := session.ListResources(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListResources: %v", err)
+	}
+
+	found := false
+	for _, r := range res.Resources {
+		if r.URI == "contextd://help" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected static resource contextd://help to be registered, got %+v", res.Resources)
+	}
+}
+
+func TestRegisterResourcesListsTemplates(t *testing.T) {
+	s := newResourceTestServer(t)
+	session := connectResourceSession(t, s)
+	ctx := context.Background()
+
+	res, err := session.ListResourceTemplates(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListResourceTemplates: %v", err)
+	}
+
+	got := make(map[string]bool, len(res.ResourceTemplates))
+	for _, tmpl := range res.ResourceTemplates {
+		got[tmpl.URITemplate] = true
+	}
+
+	want := []string{
+		"contextd://{project_id}/memories",
+		"contextd://{project_id}/memory/{id}",
+		"contextd://{project_id}/checkpoints",
+		"contextd://{project_id}/checkpoint/{id}",
+		"contextd://{project_id}/remediation/{id}",
+		"contextd://{project_id}/remediations{?query}",
+	}
+	for _, uri := range want {
+		if !got[uri] {
+			t.Errorf("expected resource template %q to be registered, got %v", uri, got)
+		}
+	}
+}
+
+func TestReadHelpResourceReturnsJSON(t *testing.T) {
+	s := newResourceTestServer(t)
+	session := connectResourceSession(t, s)
+	ctx := context.Background()
+
+	res, err := session.ReadResource(ctx, &mcp.ReadResourceParams{URI: "contextd://help"})
+	if err != nil {
+		t.Fatalf("ReadResource(help): %v", err)
+	}
+	if len(res.Contents) != 1 {
+		t.Fatalf("expected 1 content, got %d", len(res.Contents))
+	}
+	c := res.Contents[0]
+	if c.URI != "contextd://help" {
+		t.Errorf("expected content URI contextd://help, got %q", c.URI)
+	}
+	if c.MIMEType != "application/json" {
+		t.Errorf("expected MIME type application/json, got %q", c.MIMEType)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(c.Text), &parsed); err != nil {
+		t.Fatalf("help content is not valid JSON: %v\ntext: %s", err, c.Text)
+	}
+	if parsed["scheme"] != "contextd" {
+		t.Errorf("expected scheme \"contextd\" in help JSON, got %v", parsed["scheme"])
+	}
+	if _, ok := parsed["resources"]; !ok {
+		t.Errorf("expected \"resources\" key in help JSON, got %v", parsed)
+	}
+}
+
+func TestParseResourceURI(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr bool
+		project string
+		kind    string
+		id      string
+		query   string
+	}{
+		{name: "memories collection", raw: "contextd://proj/memories", project: "proj", kind: "memories"},
+		{name: "single memory", raw: "contextd://proj/memory/abc123", project: "proj", kind: "memory", id: "abc123"},
+		{name: "remediations with query", raw: "contextd://proj/remediations?query=null+pointer", project: "proj", kind: "remediations", query: "null pointer"},
+		{name: "wrong scheme", raw: "http://proj/memories", wantErr: true},
+		{name: "missing kind", raw: "contextd://proj", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseResourceURI(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got none", tt.raw)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.projectID != tt.project || got.kind != tt.kind || got.id != tt.id || got.query != tt.query {
+				t.Errorf("parseResourceURI(%q) = %+v, want project=%q kind=%q id=%q query=%q",
+					tt.raw, got, tt.project, tt.kind, tt.id, tt.query)
+			}
+		})
+	}
+}
+
+func TestResourceURIBuilders(t *testing.T) {
+	if got := collectionResourceURI("proj", "memories"); got != "contextd://proj/memories" {
+		t.Errorf("collectionResourceURI = %q", got)
+	}
+	if got := itemResourceURI("proj", "memory", "abc"); got != "contextd://proj/memory/abc" {
+		t.Errorf("itemResourceURI = %q", got)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -62,7 +62,7 @@ type Config struct {
 // DefaultConfig returns sensible defaults.
 func DefaultConfig() *Config {
 	return &Config{
-		Name:    "contextd-v2",
+		Name:    "contextd",
 		Version: "1.0.0",
 		Logger:  zap.NewNop(),
 		IgnoreFiles: []string{

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -114,13 +114,22 @@ func NewServer(
 		return nil, fmt.Errorf("scrubber is required")
 	}
 
-	// Create MCP server
+	// Create MCP server.
+	//
+	// Subscribe/Unsubscribe handlers are required for the SDK to advertise the
+	// resources.subscribe capability and track per-session resource
+	// subscriptions — the basis of the agent-swarm notification mechanism (see
+	// docs/spec/mcp-protocol/notifications-agent-swarm.md). The SDK records the
+	// subscriptions itself; these handlers exist only to enable that path.
 	mcpServer := mcp.NewServer(
 		&mcp.Implementation{
 			Name:    cfg.Name,
 			Version: cfg.Version,
 		},
-		nil,
+		&mcp.ServerOptions{
+			SubscribeHandler:   func(context.Context, *mcp.SubscribeRequest) error { return nil },
+			UnsubscribeHandler: func(context.Context, *mcp.UnsubscribeRequest) error { return nil },
+		},
 	)
 
 	// Create ignore parser for repository indexing
@@ -145,6 +154,11 @@ func NewServer(
 	if err := s.registerTools(); err != nil {
 		return nil, fmt.Errorf("failed to register tools: %w", err)
 	}
+
+	// Register resources (memories/checkpoints/remediations) and prompts.
+	// Served over both stdio and Streamable HTTP via the shared *mcp.Server.
+	s.registerResources()
+	s.registerPrompts()
 
 	return s, nil
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -188,7 +188,7 @@ func TestNewServer(t *testing.T) {
 func TestDefaultConfig(t *testing.T) {
 	cfg := DefaultConfig()
 	require.NotNil(t, cfg)
-	require.Equal(t, "contextd-v2", cfg.Name)
+	require.Equal(t, "contextd", cfg.Name)
 	require.Equal(t, "1.0.0", cfg.Version)
 	require.NotNil(t, cfg.Logger)
 }

--- a/internal/mcp/streamable.go
+++ b/internal/mcp/streamable.go
@@ -1,0 +1,124 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.uber.org/zap"
+)
+
+// StreamableHTTPConfig configures the standalone Streamable HTTP MCP server.
+type StreamableHTTPConfig struct {
+	// Host to bind (default: "localhost").
+	Host string
+	// Port to listen on.
+	Port int
+	// Path the MCP endpoint is mounted at (default: "/mcp").
+	Path string
+	// Stateless, when true, disables Mcp-Session-Id validation.
+	//
+	// Keep this false (the default) for agent-swarm use: stateful sessions are
+	// what allow multiple connected clients (agents) to subscribe to
+	// resource-update notifications and receive server-initiated messages. See
+	// docs/spec/mcp-protocol/notifications-agent-swarm.md.
+	Stateless bool
+	// ReadHeaderTimeout guards against slow-loris clients (default: 10s).
+	ReadHeaderTimeout time.Duration
+}
+
+func (c *StreamableHTTPConfig) withDefaults() StreamableHTTPConfig {
+	out := *c
+	if out.Host == "" {
+		out.Host = "localhost"
+	}
+	if out.Path == "" {
+		out.Path = "/mcp"
+	}
+	if out.ReadHeaderTimeout == 0 {
+		out.ReadHeaderTimeout = 10 * time.Second
+	}
+	return out
+}
+
+// StreamableHandler returns the SDK Streamable HTTP handler bound to this
+// server. It is exposed so the handler can be mounted into any net/http or Echo
+// server. The same underlying MCP server is reused across sessions.
+func (s *Server) StreamableHandler(stateless bool) http.Handler {
+	return mcpsdk.NewStreamableHTTPHandler(
+		func(*http.Request) *mcpsdk.Server { return s.mcp },
+		&mcpsdk.StreamableHTTPOptions{Stateless: stateless},
+	)
+}
+
+// RunHTTP runs the MCP server over the Streamable HTTP transport using a
+// dedicated Echo server.
+//
+// This is intentionally a SEPARATE server from internal/http (the REST API).
+// Keeping them apart lets the MCP transport be developed and tested in
+// isolation; the two are expected to be consolidated later.
+//
+// RunHTTP blocks until ctx is cancelled or the server fails, then shuts down
+// gracefully.
+func (s *Server) RunHTTP(ctx context.Context, cfg StreamableHTTPConfig) error {
+	cfg = cfg.withDefaults()
+
+	e := echo.New()
+	e.HideBanner = true
+	e.HidePort = true
+	e.Use(middleware.Recover())
+	e.Use(middleware.RequestID())
+
+	// MCP Streamable HTTP uses a single endpoint for both POST (client→server
+	// messages) and GET (server→client SSE stream).
+	e.Any(cfg.Path, echo.WrapHandler(s.StreamableHandler(cfg.Stateless)))
+
+	e.GET("/health", func(c echo.Context) error {
+		return c.JSON(http.StatusOK, map[string]string{
+			"status":    "ok",
+			"transport": "streamable-http",
+			"endpoint":  cfg.Path,
+		})
+	})
+
+	addr := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           e,
+		ReadHeaderTimeout: cfg.ReadHeaderTimeout,
+	}
+
+	s.logger.Info("starting MCP server on streamable HTTP transport",
+		zap.String("addr", addr),
+		zap.String("path", cfg.Path),
+		zap.Bool("stateless", cfg.Stateless),
+	)
+
+	errCh := make(chan error, 1)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("streamable HTTP shutdown: %w", err)
+		}
+		return nil
+	case err := <-errCh:
+		if err != nil {
+			return fmt.Errorf("streamable HTTP server: %w", err)
+		}
+		return nil
+	}
+}

--- a/internal/mcp/streamable.go
+++ b/internal/mcp/streamable.go
@@ -2,8 +2,10 @@ package mcp
 
 import (
 	"context"
+	"crypto/subtle"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -11,6 +13,27 @@ import (
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.uber.org/zap"
 )
+
+// bearerTokenMiddleware enforces "Authorization: Bearer <token>" using a
+// constant-time comparison to avoid leaking the token via timing.
+func bearerTokenMiddleware(token string) echo.MiddlewareFunc {
+	want := []byte(token)
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			h := c.Request().Header.Get(echo.HeaderAuthorization)
+			const prefix = "Bearer "
+			if !strings.HasPrefix(h, prefix) {
+				return echo.NewHTTPError(http.StatusUnauthorized, "missing bearer token")
+			}
+			got := []byte(strings.TrimSpace(h[len(prefix):]))
+			if subtle.ConstantTimeEq(int32(len(got)), int32(len(want))) != 1 ||
+				subtle.ConstantTimeCompare(got, want) != 1 {
+				return echo.NewHTTPError(http.StatusUnauthorized, "invalid bearer token")
+			}
+			return next(c)
+		}
+	}
+}
 
 // StreamableHTTPConfig configures the standalone Streamable HTTP MCP server.
 type StreamableHTTPConfig struct {
@@ -27,6 +50,11 @@ type StreamableHTTPConfig struct {
 	// resource-update notifications and receive server-initiated messages. See
 	// docs/spec/mcp-protocol/notifications-agent-swarm.md.
 	Stateless bool
+	// Token, when non-empty, requires clients to present
+	// "Authorization: Bearer <Token>" on the MCP endpoint. When empty, the
+	// endpoint is served unauthenticated (intended for localhost/testing) and
+	// RunHTTP logs a prominent warning.
+	Token string
 	// ReadHeaderTimeout guards against slow-loris clients (default: 10s).
 	ReadHeaderTimeout time.Duration
 }
@@ -74,8 +102,16 @@ func (s *Server) RunHTTP(ctx context.Context, cfg StreamableHTTPConfig) error {
 	e.Use(middleware.RequestID())
 
 	// MCP Streamable HTTP uses a single endpoint for both POST (client→server
-	// messages) and GET (server→client SSE stream).
-	e.Any(cfg.Path, echo.WrapHandler(s.StreamableHandler(cfg.Stateless)))
+	// messages) and GET (server→client SSE stream). Bearer auth (when a token
+	// is configured) guards only this endpoint; /health stays open.
+	mcpEndpoint := e.Group(cfg.Path)
+	if cfg.Token != "" {
+		mcpEndpoint.Use(bearerTokenMiddleware(cfg.Token))
+	} else {
+		s.logger.Warn("MCP streamable HTTP server running WITHOUT authentication; " +
+			"set a token (--mcp-http-token / CONTEXTD_MCP_HTTP_TOKEN) before exposing beyond localhost")
+	}
+	mcpEndpoint.Any("", echo.WrapHandler(s.StreamableHandler(cfg.Stateless)))
 
 	e.GET("/health", func(c echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{

--- a/internal/mcp/streamable_test.go
+++ b/internal/mcp/streamable_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/labstack/echo/v4"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.uber.org/zap"
 )
@@ -66,5 +67,46 @@ func TestStreamableHandler_Initialize(t *testing.T) {
 func TestStreamableHandler_NotNil(t *testing.T) {
 	if newBareServer(t).StreamableHandler(false) == nil {
 		t.Fatal("StreamableHandler returned nil")
+	}
+}
+
+// TestBearerTokenMiddleware checks the auth gate on the MCP endpoint.
+func TestBearerTokenMiddleware(t *testing.T) {
+	const token = "s3cr3t-token"
+	h := bearerTokenMiddleware(token)(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	cases := []struct {
+		name       string
+		authHeader string
+		wantStatus int
+	}{
+		{"no header", "", http.StatusUnauthorized},
+		{"wrong scheme", "Basic abc", http.StatusUnauthorized},
+		{"wrong token", "Bearer nope", http.StatusUnauthorized},
+		{"correct token", "Bearer " + token, http.StatusOK},
+	}
+
+	e := echo.New()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader("{}"))
+			if tc.authHeader != "" {
+				req.Header.Set(echo.HeaderAuthorization, tc.authHeader)
+			}
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			err := h(c)
+			status := rec.Code
+			if err != nil {
+				if he, ok := err.(*echo.HTTPError); ok {
+					status = he.Code
+				}
+			}
+			if status != tc.wantStatus {
+				t.Errorf("status = %d, want %d (err=%v)", status, tc.wantStatus, err)
+			}
+		})
 	}
 }

--- a/internal/mcp/streamable_test.go
+++ b/internal/mcp/streamable_test.go
@@ -1,0 +1,70 @@
+package mcp
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.uber.org/zap"
+)
+
+// newBareServer builds a Server with only the fields the Streamable HTTP
+// transport needs (mcp + logger). It avoids standing up the full service graph.
+func newBareServer(t *testing.T) *Server {
+	t.Helper()
+	return &Server{
+		mcp:    mcpsdk.NewServer(&mcpsdk.Implementation{Name: "contextd", Version: "test"}, nil),
+		logger: zap.NewNop(),
+	}
+}
+
+// TestStreamableHandler_Initialize verifies the Streamable HTTP transport
+// completes an MCP initialize handshake and reports the contextd serverInfo.
+func TestStreamableHandler_Initialize(t *testing.T) {
+	srv := httptest.NewServer(newBareServer(t).StreamableHandler(true /* stateless */))
+	defer srv.Close()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{` +
+		`"protocolVersion":"2025-06-18","capabilities":{},` +
+		`"clientInfo":{"name":"test-client","version":"1.0.0"}}}`
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	out := string(raw)
+	if !strings.Contains(out, `"protocolVersion"`) {
+		t.Errorf("response missing protocolVersion: %s", out)
+	}
+	if !strings.Contains(out, "contextd") {
+		t.Errorf("response missing contextd serverInfo: %s", out)
+	}
+}
+
+// TestStreamableHandler_NotNil is a guard that the handler constructor wires up.
+func TestStreamableHandler_NotNil(t *testing.T) {
+	if newBareServer(t).StreamableHandler(false) == nil {
+		t.Fatal("StreamableHandler returned nil")
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -340,17 +340,34 @@ func (s *Server) registerCheckpointTools() {
 			return nil, checkpointResumeOutput{}, toolErr
 		}
 
-		resumeReq := &checkpoint.ResumeRequest{
-			CheckpointID: args.CheckpointID,
-			TenantID:     args.TenantID,
-			Level:        args.Level,
-		}
-
 		// Add tenant context to Go context for vectorstore operations
 		ctx, err := withTenantContext(ctx, args.TenantID, "", "")
 		if err != nil {
 			toolErr = err
 			return nil, checkpointResumeOutput{}, err
+		}
+
+		// If no checkpoint was specified, ask the client to choose (via MCP
+		// elicitation) or fall back to presenting the list.
+		if args.CheckpointID == "" {
+			id, listMsg, chooseErr := s.chooseCheckpointViaElicit(ctx, req.Session, args.TenantID)
+			if chooseErr != nil {
+				toolErr = chooseErr
+				return nil, checkpointResumeOutput{}, chooseErr
+			}
+			if id == "" {
+				// Could not auto-resolve; return the list for manual selection.
+				return &mcp.CallToolResult{
+					Content: []mcp.Content{&mcp.TextContent{Text: listMsg}},
+				}, checkpointResumeOutput{}, nil
+			}
+			args.CheckpointID = id
+		}
+
+		resumeReq := &checkpoint.ResumeRequest{
+			CheckpointID: args.CheckpointID,
+			TenantID:     args.TenantID,
+			Level:        args.Level,
 		}
 
 		response, err := s.checkpointSvc.Resume(ctx, resumeReq)
@@ -1016,11 +1033,15 @@ func (s *Server) registerRepositoryTools() {
 			return nil, repositoryIndexOutput{}, toolErr
 		}
 
+		s.clientLog(ctx, req.Session, "info", fmt.Sprintf("indexing repository %s (branch: %s)", validPath, args.Branch))
+
 		result, err := s.repositorySvc.IndexRepository(ctx, validPath, opts)
 		if err != nil {
 			toolErr = fmt.Errorf("repository index failed: %w", err)
 			return nil, repositoryIndexOutput{}, toolErr
 		}
+
+		s.clientLog(ctx, req.Session, "info", fmt.Sprintf("indexed %d files from %s", result.FilesIndexed, result.Path))
 
 		// Ensure output arrays are never nil (MCP schema validation requires arrays, not null)
 		outputInclude := result.IncludePatterns

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -235,6 +235,9 @@ func (s *Server) registerCheckpointTools() {
 			return nil, checkpointSaveOutput{}, toolErr
 		}
 
+		// Notify swarm members subscribed to this project's checkpoints collection.
+		s.notifyCollectionUpdated(ctx, projectID, "checkpoints")
+
 		result := checkpointSaveOutput{
 			ID:          cp.ID,
 			SessionID:   cp.SessionID,
@@ -516,7 +519,7 @@ func (s *Server) registerRemediationTools() {
 		defer s.startMetrics(ctx, "remediation_record", &toolErr)()
 
 		// Validate and derive tenant context from project path
-		validPath, tenantID, _, err := s.validateAndDeriveProjectPath(args.ProjectPath, args.TenantID)
+		validPath, tenantID, projectID, err := s.validateAndDeriveProjectPath(args.ProjectPath, args.TenantID)
 		if err != nil {
 			toolErr = err
 			return nil, remediationRecordOutput{}, err
@@ -558,6 +561,9 @@ func (s *Server) registerRemediationTools() {
 			toolErr = fmt.Errorf("remediation record failed: %w", err)
 			return nil, remediationRecordOutput{}, toolErr
 		}
+
+		// Notify swarm members subscribed to this project's remediations collection.
+		s.notifyCollectionUpdated(ctx, projectID, "remediations")
 
 		result := remediationRecordOutput{
 			ID:         rem.ID,
@@ -1282,6 +1288,9 @@ func (s *Server) registerMemoryTools() {
 			toolErr = fmt.Errorf("memory record failed: %w", err)
 			return nil, memoryRecordOutput{}, toolErr
 		}
+
+		// Notify swarm members subscribed to this project's memories collection.
+		s.notifyCollectionUpdated(ctx, args.ProjectID, "memories")
 
 		output := memoryRecordOutput{
 			ID:         memory.ID,

--- a/plugins/contextd/README.md
+++ b/plugins/contextd/README.md
@@ -33,6 +33,26 @@ conversation indexing, reflection).
 **Hook**: a defensive `SessionStart` hook that reminds Claude to use contextd
 when the binary is present, and no-ops silently when it isn't.
 
+## Beyond Claude Code
+
+The bundled contextd MCP server now also exposes capabilities that are
+available to any MCP host whenever the server is running:
+
+- **MCP Resources** — read-only, secret-scrubbed JSON views of memories,
+  checkpoints, and remediations (including a `contextd://help` resource).
+- **MCP Prompts** — six workflow prompts (`contextd_checkpoint`,
+  `contextd_remember`, `contextd_diagnose`, `contextd_resume`,
+  `contextd_status`, `contextd_search`).
+- **Remote hosting** — Streamable HTTP transport with optional bearer-token
+  auth for running contextd as a shared remote MCP server.
+- **Agent-swarm notifications** — resource-update notifications broadcast when
+  shared memories, checkpoints, or remediations are recorded, so multiple
+  agents can stay in sync.
+
+See [../../docs/CONTEXTD.md](../../docs/CONTEXTD.md) and
+[../../docs/spec/mcp-protocol/notifications-agent-swarm.md](../../docs/spec/mcp-protocol/notifications-agent-swarm.md)
+for details.
+
 ## Prerequisites
 
 The `contextd` binary must be on `PATH` for the MCP server to start:


### PR DESCRIPTION
## Summary

Expands contextd's MCP server from a Tools-only/stdio surface to the full MCP server surface, evaluated against the [MCP architecture spec](https://modelcontextprotocol.io/docs/learn/architecture). Adds **Resources**, **Prompts**, the **Streamable HTTP** transport for remote hosting (with bearer auth), the **logging** and **elicitation** client primitives, and an **agent-swarm notification** mechanism.

Plan & decisions: `docs/plans/2026-06-19-mcp-protocol-expansion.md`.

## What's included

**Resources (#1)** — `internal/mcp/resources.go`
- `contextd://help` + templates: `…/memories`, `…/memory/{id}`, `…/checkpoints`, `…/checkpoint/{id}`, `…/remediation/{id}`, `…/remediations{?query}`.
- Read-only JSON, secret-scrubbed, tenant-scoped via the `project_id` in the URI, fail-closed.

**Prompts (#2)** — `internal/mcp/prompts.go`
- Six static workflow prompts mirroring the slash commands: `contextd_checkpoint`, `contextd_remember`, `contextd_diagnose`, `contextd_resume`, `contextd_status`, `contextd_search`.

**Streamable HTTP transport (#3)** — `internal/mcp/streamable.go`
- Dedicated **Echo** server (separate from the REST `--http-port` API), endpoint `/mcp` + `/health`, stateful sessions. Flags `--mcp-http-port` / `--mcp-http-host`.
- **Bearer-token auth** (constant-time compare): `--mcp-http-token` / `CONTEXTD_MCP_HTTP_TOKEN`; `/health` open; warns loudly when unauthenticated.

**Client primitives (#4)** — `internal/mcp/clientcomm.go`
- MCP **logging**: progress on `repository_index` (no-op-safe; SDK auto-advertises the capability).
- **Elicitation**: `checkpoint_resume` with no id auto-selects when one checkpoint exists, elicits a choice when many, and falls back to a scrubbed list when the client can't elicit.

**Agent-swarm notifications (#6)** — `internal/mcp/notifications.go` + `docs/spec/mcp-protocol/notifications-agent-swarm.md`
- Agents `resources/subscribe` to a collection URI; when any agent records a memory/remediation/checkpoint, subscribers get `notifications/resources/updated` and re-read shared knowledge.
- `NewServer` now sets `Subscribe`/`Unsubscribe` handlers so the SDK advertises `resources.subscribe` and tracks subscriptions.

**serverInfo rename (#5)** — `contextd-v2` → `contextd`.

## Tests

New tests cover: resource registration/help/templates/read, prompt listing + argument templating, **end-to-end notification delivery** over in-memory transports, bearer-auth gate (missing/wrong/correct), streamable `initialize` handshake, and checkpoint-resume elicitation resolution. `go build ./...`, `go vet`, and the full `internal/mcp` suite pass.

## Docs

`docs/CONTEXTD.md` (Resources/Prompts tables, dual-transport Running Modes, swarm section), `README.md` (remote hosting + curl example), `CHANGELOG.md` (Unreleased), `plugins/contextd/README.md` (Priority #3).

## Notes / follow-ups

- **No version bump** included — `0.5.0 → 0.6.0` (lockstep `VERSION`/`plugin.json`/`marketplace.json`) left for the release process.
- **Phase E (deferred):** fold the REST routes onto the Echo MCP server and retire `internal/http`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dx7G4kSYGsGi2SFmkhs8QK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dx7G4kSYGsGi2SFmkhs8QK)_